### PR TITLE
Add workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "./docker"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: '3.8' 
 
       - name: Install scancode 
-        run: pip install scancode-toolkit extractcode
+        run: pip install scancode-toolkit==21.3.3
 
       - name: Build with Maven
         run: mvn install -DskipTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,93 @@
+name: Build application 
+
+on:
+  push:
+
+env:
+  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  DOCKER_ORGANIZATION: philipssoftware
+  GITHUB_ORGANIZATION: philips-software
+
+jobs:
+  build-and-test-frontend:
+    name: Build frontend project
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v2
+
+      - uses: subosito/flutter-action@v1
+        with:
+          flutter-version: '2.0.5'
+
+      - name: Install UI
+        run: |
+          cd ui
+          ./install_ui
+
+  
+  build-and-test-backend:
+    name: Build backend project
+    runs-on: ubuntu-latest
+    needs: build-and-test-frontend
+
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11.0.1'
+          distribution: 'zulu'
+
+      - name: Cache build artifacts
+        uses: actions/cache@v2.1.5
+        with:
+          path: |
+            target/**/*.xml
+            target/*.jar
+          key: bom-base-${{ github.sha }}
+
+      - name: Setup python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '3.8' 
+
+      - name: Install scancode 
+        run: pip install scancode-toolkit extractcode
+
+      - name: Build with Maven
+        run: mvn install -DskipTests
+
+      - name: Test with Maven
+        run: mvn test
+
+  create-docker-image:
+    name: "Create docker image"
+    needs: build-and-test-backend
+
+    runs-on: ubuntu-latest
+
+    if: success()
+
+    steps:
+      - name: Checkout
+
+        uses: actions/checkout@v2
+
+      - name: Cache build artifacts
+        uses: actions/cache@v2.1.5
+        with:
+          path: |
+            target/**/*.xml
+            target/*.jar
+          key: bom-base-${{ github.sha }}
+
+      - name: Build Docker Images
+        uses: philips-software/docker-ci-scripts@v3.2.1
+        with:
+          dockerfile: docker/Dockerfile
+          image-name: bom-base 
+          tags: 0 0.1 0.1.0 v0.1.0 latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: '3.8' 
 
       - name: Install scancode 
-        run: pip install scancode-toolkit==21.3.3
+        run: pip install scancode-toolkit==21.3.31
 
       - name: Build with Maven
         run: mvn install -DskipTests

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,0 +1,24 @@
+name: Get licenses
+
+on:
+  push:
+
+jobs:
+  scanLicenses:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        java-version: '11.0.1' 
+        distribution: 'zulu'
+
+    - name: Create spdx-file
+      id: spdx-builder
+      uses: philips-software/spdx-action@v0.6.0
+      with:
+        project: bom-base
+    - uses: actions/upload-artifact@v2
+      with:
+        name: licenses
+        path: ${{ steps.spdx-builder.outputs.spdx-file }}

--- a/.spdx-builder.yml
+++ b/.spdx-builder.yml
@@ -14,4 +14,3 @@ projects:
       - "annotation*"
       - "archives"
   - id: "Pub::ui/pubspec.yaml:"
-    purl: "pkg:pub/ui/pubspec@v0.0.1"

--- a/.spdx-builder.yml
+++ b/.spdx-builder.yml
@@ -1,0 +1,17 @@
+document:
+  title: "Bom-Base"
+  organization: "Philips Research"
+  comment:
+  key:
+  namespace: "https://research.philips.com/bom-base"
+projects:
+  - id: "Maven:com.philips.research:BOM-base:0.0.1"
+    purl: "pkg:maven/philips/BOM-base@v0.0.1"
+    excluded:
+      - "test*"
+      - "development*"
+      - "runtime*"
+      - "annotation*"
+      - "archives"
+  - id: "Pub::ui/pubspec.yaml:"
+    purl: "pkg:pub/ui/pubspec@v0.0.1"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,9 @@
-FROM philipssoftware/openjdk:11
+FROM philipssoftware/python:java
 
 COPY target/BOM-base*.jar /app/service.jar
 COPY docker/start.sh /app/start.sh
+
+RUN pip install scancode-toolkit==21.3.31
 
 EXPOSE 8080
 


### PR DESCRIPTION
Add build workflow.

- Scan licenses with SPDX-Builder
- Build and test frontend
- Build and test backend
- Build and store docker-image

Closes #3

Note: SPDX-builder does not have the dart packages yet, because of an issue in the docker-ort image. 
New version of ORT docker image is being created as we speak: https://github.com/philips-software/docker-ort/commit/659f17a62c226d616c9786964b2b444cd8304155

No need to block this PR for that.