### PR TITLE
Feature(backend): Filter types for ClearlyDefined

### DIFF
--- a/src/main/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedAPI.java
+++ b/src/main/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedAPI.java
@@ -17,9 +17,6 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public interface ClearlyDefinedAPI {
-    //TODO Is this even a realistic score?
-    int MAX_SCORE = 70;
-
     @GET("definitions/{type}/{provider}/{namespace}/{name}/{revision}")
     Call<ResponseJson> getDefinition(@Path("type") String type, @Path("provider") String provider, @Path("namespace") String namespace,
                                      @Path("name") String name, @Path("revision") String revision);
@@ -37,16 +34,12 @@ public interface ClearlyDefinedAPI {
 
         @Override
         public int getDescribedScore() {
-            return relativeScore(described.score.total);
+            return described.score.total;
         }
 
         @Override
         public int getLicensedScore() {
-            return relativeScore(licensed.score.total);
-        }
-
-        private int relativeScore(int score) {
-            return Math.round((score / 100f) * MAX_SCORE);
+            return licensed.score.total;
         }
 
         @Override

--- a/src/main/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedClient.java
+++ b/src/main/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedClient.java
@@ -10,9 +10,11 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.github.packageurl.PackageURL;
 import com.philips.research.bombase.core.clearlydefined.ClearlyDefinedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
@@ -23,10 +25,11 @@ import java.util.Map;
 import java.util.Optional;
 
 class ClearlyDefinedClient {
+    private static final Logger LOG = LoggerFactory.getLogger(ClearlyDefinedClient.class);
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.NON_PRIVATE)
-            .setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE);
+            .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
     private static final Map<String, String> TYPE_MAPPING = Map.of( // Default is 1:1 mapping from type
             "cocoapods", "pod",
             "cargo", "crate",
@@ -66,6 +69,7 @@ class ClearlyDefinedClient {
         try {
             final var response = query.execute();
             if (!response.isSuccessful()) {
+                LOG.info("Query={}", response.raw().request().url());
                 throw new ClearlyDefinedException("ClearlyDefined server responded with status " + response.code());
             }
             return Optional.ofNullable(response.body());

--- a/src/test/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedAPITest.java
+++ b/src/test/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedAPITest.java
@@ -14,16 +14,16 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ClearlyDefinedAPITest {
-    private static final int MAX_SCORE = 70;
+    private static final int SCORE = 42;
 
     @Test
     void derivesMetadataScore() {
         final var response = new ResponseJson();
         response.described = new DescribedJson();
         response.described.score = new ScoreJson();
-        response.described.score.total = 50;
+        response.described.score.total = SCORE;
 
-        assertThat(response.getDescribedScore()).isEqualTo((int) (50 / 100f * MAX_SCORE));
+        assertThat(response.getDescribedScore()).isEqualTo(SCORE);
     }
 
     @Test
@@ -31,9 +31,9 @@ class ClearlyDefinedAPITest {
         final var response = new ResponseJson();
         response.licensed = new LicensedJson();
         response.licensed.score = new ScoreJson();
-        response.licensed.score.total = 50;
+        response.licensed.score.total = SCORE;
 
-        assertThat(response.getLicensedScore()).isEqualTo((int) (50 / 100f * MAX_SCORE));
+        assertThat(response.getLicensedScore()).isEqualTo(SCORE);
     }
 
     @Test

--- a/src/test/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedHarvesterTest.java
+++ b/src/test/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedHarvesterTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 class ClearlyDefinedHarvesterTest {
-    private static final String TYPE = "type";
+    private static final String TYPE = "maven";
     private static final String NAMESPACE = "namespace";
     private static final String NAME = "name";
     private static final String VERSION = "version";
@@ -36,8 +36,11 @@ class ClearlyDefinedHarvesterTest {
     private static final String DETECTED_LICENSE = "Detected";
     private static final String SHA1 = "Sha1";
     private static final String SHA256 = "Sha256";
-    private static final int META_SCORE = 70;
-    private static final int LICENSE_SCORE = 60;
+    private static final int MAX_SCORE = 70;
+    private static final int META_SCORE = 73;
+    private static final int META_TOTAL_SCORE = Math.round((META_SCORE * MAX_SCORE)/100f);
+    private static final int LICENSE_SCORE = 42;
+    private static final int LICENSE_TOTAL_SCORE = Math.round((LICENSE_SCORE * MAX_SCORE)/100f);
 
     private final ClearlyDefinedClient client = mock(ClearlyDefinedClient.class);
     private final ClearlyDefinedHarvester listener = new ClearlyDefinedHarvester(client);
@@ -57,6 +60,13 @@ class ClearlyDefinedHarvesterTest {
             final var task = listener.onUpdated(PURL, Set.of(), Map.of());
 
             assertThat(task).isNotEmpty();
+        }
+
+        @Test
+        void returnsNothing_unsupportedPurlType() {
+            final var task = listener.onUpdated(toPurl("pkg:generic/name@version"), Set.of(), Map.of());
+
+            assertThat(task).isEmpty();
         }
 
         @Test
@@ -94,15 +104,15 @@ class ClearlyDefinedHarvesterTest {
 
             task.accept(pkg);
 
-            verify(pkg).update(Field.TITLE, META_SCORE, NAME);
-            verify(pkg).update(Field.SOURCE_LOCATION, META_SCORE, SOURCE_LOCATION);
-            verify(pkg).update(Field.DOWNLOAD_LOCATION, META_SCORE, DOWNLOAD_LOCATION);
-            verify(pkg).update(Field.HOME_PAGE, META_SCORE, HOMEPAGE);
-            verify(pkg).update(Field.ATTRIBUTION, META_SCORE, ATTRIBUTION);
-            verify(pkg).update(Field.DECLARED_LICENSE, META_SCORE, DECLARED_LICENSE);
-            verify(pkg).update(Field.DETECTED_LICENSES, LICENSE_SCORE, List.of(DETECTED_LICENSE));
-            verify(pkg).update(Field.SHA1, META_SCORE, SHA1);
-            verify(pkg).update(Field.SHA256, META_SCORE, SHA256);
+            verify(pkg).update(Field.TITLE, META_TOTAL_SCORE, NAME);
+            verify(pkg).update(Field.SOURCE_LOCATION, META_TOTAL_SCORE, SOURCE_LOCATION);
+            verify(pkg).update(Field.DOWNLOAD_LOCATION, META_TOTAL_SCORE, DOWNLOAD_LOCATION);
+            verify(pkg).update(Field.HOME_PAGE, META_TOTAL_SCORE, HOMEPAGE);
+            verify(pkg).update(Field.ATTRIBUTION, META_TOTAL_SCORE, ATTRIBUTION);
+            verify(pkg).update(Field.DECLARED_LICENSE, META_TOTAL_SCORE, DECLARED_LICENSE);
+            verify(pkg).update(Field.DETECTED_LICENSES, LICENSE_TOTAL_SCORE, List.of(DETECTED_LICENSE));
+            verify(pkg).update(Field.SHA1, META_TOTAL_SCORE, SHA1);
+            verify(pkg).update(Field.SHA256, META_TOTAL_SCORE, SHA256);
         }
     }
 }


### PR DESCRIPTION
Only creates a harvesting task for packages that are supported by
ClearlyDefined.

- Move attribute score for ClearlyDefined harvester from API to the harvester.
- Log ClearlyDefined query in case status is not OK.