### PR TITLE
Feat(backend): Structure "trust" in metadata quality

### DIFF
--- a/src/main/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedAPI.java
+++ b/src/main/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedAPI.java
@@ -7,6 +7,7 @@ package com.philips.research.bombase.core.clearlydefined.domain;
 
 import com.philips.research.bombase.core.meta.PackageMetadata;
 import com.philips.research.bombase.core.meta.registry.Field;
+import com.philips.research.bombase.core.meta.registry.Trust;
 import pl.tlinkowski.annotation.basic.NullOr;
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -21,8 +22,6 @@ import java.util.function.Function;
 
 public interface ClearlyDefinedAPI {
     Set<String> IGNORED_LICENSES = Set.of("NOASSERTION", "OTHER");
-    //TODO Is this a realistic value?
-    int SCORE = 70;
 
     @GET("definitions/{type}/{provider}/{namespace}/{name}/{revision}")
     Call<ResponseJson> getDefinition(@Path("type") String type, @Path("provider") String provider, @Path("namespace") String namespace,
@@ -39,8 +38,14 @@ public interface ClearlyDefinedAPI {
         }
 
         @Override
-        public int score(Field field) {
-            return SCORE;
+        public Trust trust(Field field) {
+            //noinspection SwitchStatementWithTooFewBranches
+            switch (field) {
+                case DETECTED_LICENSES:
+                    return Trust.LIKELY;
+                default:
+                    return Trust.PROBABLY;
+            }
         }
 
         @Override

--- a/src/main/java/com/philips/research/bombase/core/maven/domain/PomXml.java
+++ b/src/main/java/com/philips/research/bombase/core/maven/domain/PomXml.java
@@ -7,6 +7,7 @@ package com.philips.research.bombase.core.maven.domain;
 
 import com.philips.research.bombase.core.meta.PackageMetadata;
 import com.philips.research.bombase.core.meta.registry.Field;
+import com.philips.research.bombase.core.meta.registry.Trust;
 import pl.tlinkowski.annotation.basic.NullOr;
 
 import java.net.URI;
@@ -21,8 +22,6 @@ import java.util.stream.Collectors;
  * @see <a href="https://search.maven.org/classic/#api">POM format</a>
  */
 class PomXml implements PackageMetadata {
-    private static final int MAVEN_SCORE = 80;
-
     @NullOr String name;
     @NullOr String description;
     @NullOr String url;
@@ -31,8 +30,8 @@ class PomXml implements PackageMetadata {
     @NullOr ReferenceXml scm;
 
     @Override
-    public int score(Field field) {
-        return MAVEN_SCORE;
+    public Trust trust(Field field) {
+        return Trust.LIKELY;
     }
 
     @Override

--- a/src/main/java/com/philips/research/bombase/core/meta/AbstractRepoHarvester.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/AbstractRepoHarvester.java
@@ -47,16 +47,16 @@ public abstract class AbstractRepoHarvester implements MetaRegistry.PackageListe
     private void harvest(PackageURL purl, PackageAttributeEditor editor) {
         try {
             client.read(purl).ifPresentOrElse(def -> {
-                def.getTitle().ifPresent(title -> editor.update(Field.TITLE, def.score(Field.TITLE), title));
-                def.getDescription().ifPresent(description -> editor.update(Field.DESCRIPTION, def.score(Field.DESCRIPTION), description));
-                def.getSourceLocation().ifPresent(url -> editor.update(Field.SOURCE_LOCATION, def.score(Field.SOURCE_LOCATION), url));
-                def.getDownloadLocation().ifPresent(url -> editor.update(Field.DOWNLOAD_LOCATION, def.score(Field.DOWNLOAD_LOCATION), url));
-                def.getHomepage().ifPresent(url -> editor.update(Field.HOME_PAGE, def.score(Field.HOME_PAGE), url));
-                def.getAuthors().ifPresent(list -> editor.update(Field.ATTRIBUTION, def.score(Field.ATTRIBUTION), list));
-                def.getDeclaredLicense().ifPresent(license -> editor.update(Field.DECLARED_LICENSE, def.score(Field.DECLARED_LICENSE), license));
-                def.getDetectedLicenses().ifPresent(list -> editor.update(Field.DETECTED_LICENSES, def.score(Field.DETECTED_LICENSES), list));
-                def.getSha1().ifPresent(sha -> editor.update(Field.SHA1, def.score(Field.SHA1), sha));
-                def.getSha256().ifPresent(sha -> editor.update(Field.SHA256, def.score(Field.SHA256), sha));
+                def.getTitle().ifPresent(title -> editor.update(Field.TITLE, def.trust(Field.TITLE), title));
+                def.getDescription().ifPresent(description -> editor.update(Field.DESCRIPTION, def.trust(Field.DESCRIPTION), description));
+                def.getSourceLocation().ifPresent(url -> editor.update(Field.SOURCE_LOCATION, def.trust(Field.SOURCE_LOCATION), url));
+                def.getDownloadLocation().ifPresent(url -> editor.update(Field.DOWNLOAD_LOCATION, def.trust(Field.DOWNLOAD_LOCATION), url));
+                def.getHomepage().ifPresent(url -> editor.update(Field.HOME_PAGE, def.trust(Field.HOME_PAGE), url));
+                def.getAuthors().ifPresent(list -> editor.update(Field.ATTRIBUTION, def.trust(Field.ATTRIBUTION), list));
+                def.getDeclaredLicense().ifPresent(license -> editor.update(Field.DECLARED_LICENSE, def.trust(Field.DECLARED_LICENSE), license));
+                def.getDetectedLicenses().ifPresent(list -> editor.update(Field.DETECTED_LICENSES, def.trust(Field.DETECTED_LICENSES), list));
+                def.getSha1().ifPresent(sha -> editor.update(Field.SHA1, def.trust(Field.SHA1), sha));
+                def.getSha256().ifPresent(sha -> editor.update(Field.SHA256, def.trust(Field.SHA256), sha));
             }, () -> LOG.info("No metadata for {}", purl));
         } catch (Exception e) {
             throw new MetaException("Failed to harvest " + purl, e);

--- a/src/main/java/com/philips/research/bombase/core/meta/MetaInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/MetaInteractor.java
@@ -13,6 +13,7 @@ import com.philips.research.bombase.core.clearlydefined.domain.ClearlyDefinedHar
 import com.philips.research.bombase.core.maven.domain.MavenHarvester;
 import com.philips.research.bombase.core.meta.registry.Field;
 import com.philips.research.bombase.core.meta.registry.MetaRegistry;
+import com.philips.research.bombase.core.meta.registry.Trust;
 import com.philips.research.bombase.core.npm.domain.NpmHarvester;
 import com.philips.research.bombase.core.pypi.domain.PyPiHarvester;
 import com.philips.research.bombase.core.source_scan.domain.SourceLicensesHarvester;
@@ -82,7 +83,7 @@ public class MetaInteractor implements MetaService {
     public Map<String, AttributeDto> setAttributes(PackageURL purl, Map<String, @NullOr Object> values) {
         registry.edit(purl, pkg -> values.forEach((key, value) -> {
             final var field = Field.valueOf(Field.class, key.toUpperCase());
-            pkg.update(field, 100, value);
+            pkg.update(field, Trust.TRUTH, value);
         }));
         return getAttributes(purl);
     }

--- a/src/main/java/com/philips/research/bombase/core/meta/PackageMetadata.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/PackageMetadata.java
@@ -6,13 +6,14 @@
 package com.philips.research.bombase.core.meta;
 
 import com.philips.research.bombase.core.meta.registry.Field;
+import com.philips.research.bombase.core.meta.registry.Trust;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
 public interface PackageMetadata {
-    int score(Field field);
+    Trust trust(Field field);
 
     Optional<String> getTitle();
 

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/Attribute.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/Attribute.java
@@ -14,8 +14,6 @@ import java.util.Optional;
  * Current value for a field.
  */
 public class Attribute<T> implements AttributeValue<T> {
-    private static final int TRUTH = 100;
-
     private final Field field;
     private int score;
     private @NullOr T value;
@@ -39,16 +37,17 @@ public class Attribute<T> implements AttributeValue<T> {
         return score;
     }
 
-    boolean setValue(int score, @NullOr T value) {
-        if (value == null || score <= 0 || (this.score == TRUTH && score < TRUTH)) {
+    boolean setValue(Trust trust, @NullOr T value) {
+        int score = trust.getScore();
+        if (value == null) {
             return false;
         }
 
         field.validate(value);
-        if (score >= TRUTH) {
+        if (trust == Trust.TRUTH) {
             updateTruth(value);
             return true;
-        } else if (score > this.score) {
+        } else if (score >= this.score) {
             return updateValue(score, value);
         } else {
             updateAltValue(score, value);
@@ -57,7 +56,7 @@ public class Attribute<T> implements AttributeValue<T> {
     }
 
     private void updateTruth(@NullOr T value) {
-        this.score = TRUTH;
+        this.score = Trust.TRUTH.getScore();
         this.value = value;
         this.altScore = 0;
         this.altValue = null;
@@ -74,14 +73,14 @@ public class Attribute<T> implements AttributeValue<T> {
     }
 
     private void updateAltValue(int score, @NullOr T value) {
-        if (score > this.altScore) {
+        if (score >= this.altScore) {
             this.altScore = score;
             this.altValue = value;
         }
     }
 
     private boolean updateValue(int score, @NullOr T value) {
-        if (!value.equals(this.value)) {
+        if (!Objects.equals(this.value, value)) {
             replaceValue(score, value);
             return true;
         } else {

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditor.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditor.java
@@ -49,16 +49,18 @@ public class PackageAttributeEditor {
     }
 
     /**
-     * Updates the value of a field using the provided score as priority
+     * Optionally updates the value of a field based on its relative trust.
      *
-     * @param score percentage indicating how trustworthy the value is
+     * @param field the metadata attribute to overwrite
+     * @param trust indicates how reliable the value is
+     * @param value new value to assign
      */
-    public PackageAttributeEditor update(Field field, int score, @NullOr Object value) {
+    public PackageAttributeEditor update(Field field, Trust trust, @NullOr Object value) {
         if (value == null) {
             return this;
         }
 
-        final var modified = getOrCreateAttr(field).setValue(score, value);
+        final var modified = getOrCreateAttr(field).setValue(trust, value);
         if (modified) {
             modifiedFields.add(field);
         }
@@ -91,5 +93,4 @@ public class PackageAttributeEditor {
         }
         return modified;
     }
-
 }

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/Trust.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/Trust.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.meta.registry;
+
+public enum Trust {
+    MAYBE(10),
+    PROBABLY(60),
+    LIKELY(70),
+    CERTAIN(80),
+    TRUTH(100);
+
+    private final int score;
+
+    Trust(int score) {
+        this.score = score;
+    }
+
+    int getScore() {
+        return score;
+    }
+}

--- a/src/main/java/com/philips/research/bombase/core/npm/domain/NpmAPI.java
+++ b/src/main/java/com/philips/research/bombase/core/npm/domain/NpmAPI.java
@@ -8,6 +8,7 @@ package com.philips.research.bombase.core.npm.domain;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.philips.research.bombase.core.meta.PackageMetadata;
 import com.philips.research.bombase.core.meta.registry.Field;
+import com.philips.research.bombase.core.meta.registry.Trust;
 import pl.tlinkowski.annotation.basic.NullOr;
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -20,9 +21,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public interface NpmAPI {
-    // TODO Is this a proper value?
-    int NPM_SCORE = 80;
-
     @GET("{project}/{version}")
     Call<ResponseJson> getDefinition(@Path("project") String project,
                                      @Path("version") String version);
@@ -38,8 +36,8 @@ public interface NpmAPI {
         DistJson dist;
 
         @Override
-        public int score(Field field) {
-            return NPM_SCORE;
+        public Trust trust(Field field) {
+            return Trust.LIKELY;
         }
 
         @Override

--- a/src/main/java/com/philips/research/bombase/core/pypi/domain/PyPiAPI.java
+++ b/src/main/java/com/philips/research/bombase/core/pypi/domain/PyPiAPI.java
@@ -7,6 +7,7 @@ package com.philips.research.bombase.core.pypi.domain;
 
 import com.philips.research.bombase.core.meta.PackageMetadata;
 import com.philips.research.bombase.core.meta.registry.Field;
+import com.philips.research.bombase.core.meta.registry.Trust;
 import pl.tlinkowski.annotation.basic.NullOr;
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -23,8 +24,6 @@ import java.util.stream.Stream;
  * See https://warehouse.readthedocs.io/api-reference/json.html#release
  */
 public interface PyPiAPI {
-    //TODO Is this an appropriate score?
-    int PYPI_SCORE = 80;
     String SOURCE_FILE = "sdist";
     String BINARY_FILE = "bdist_wheel";
 
@@ -38,8 +37,8 @@ public interface PyPiAPI {
         List<FileJson> urls = new ArrayList<>();
 
         @Override
-        public int score(Field field) {
-            return PYPI_SCORE;
+        public Trust trust(Field field) {
+            return Trust.LIKELY;
         }
 
         @Override

--- a/src/test/java/com/philips/research/bombase/core/meta/AbstractRepoHarvesterTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/AbstractRepoHarvesterTest.java
@@ -9,6 +9,7 @@ import com.github.packageurl.PackageURL;
 import com.philips.research.bombase.core.meta.registry.Field;
 import com.philips.research.bombase.core.meta.registry.Package;
 import com.philips.research.bombase.core.meta.registry.PackageAttributeEditor;
+import com.philips.research.bombase.core.meta.registry.Trust;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ class AbstractRepoHarvesterTest {
     private static final URI DOWNLOAD_LOCATION = URI.create("https://example.com/download");
     private static final String SHA1 = "Sha1";
     private static final String SHA256 = "Sha256";
-    private static final int SCORE = 70;
+    private static final Trust TRUST = Trust.PROBABLY;
 
     private final AbstractRepoHarvester.Client client = mock(AbstractRepoHarvester.Client.class);
     private final AbstractRepoHarvester harvester = new TestHarvester(client);
@@ -96,7 +97,7 @@ class AbstractRepoHarvesterTest {
 
         @Test
         void harvestsMetadata() {
-            when(response.score(any())).thenReturn(SCORE);
+            when(response.trust(any())).thenReturn(TRUST);
             when(response.getSourceLocation()).thenReturn(Optional.of(SOURCE_LOCATION));
             when(response.getTitle()).thenReturn(Optional.of(TITLE));
             when(response.getDescription()).thenReturn(Optional.of(DESCRIPTION));
@@ -110,16 +111,16 @@ class AbstractRepoHarvesterTest {
 
             task.accept(editor);
 
-            verify(editor).update(Field.TITLE, SCORE, TITLE);
-            verify(editor).update(Field.DESCRIPTION, SCORE, DESCRIPTION);
-            verify(editor).update(Field.SOURCE_LOCATION, SCORE, SOURCE_LOCATION);
-            verify(editor).update(Field.DOWNLOAD_LOCATION, SCORE, DOWNLOAD_LOCATION);
-            verify(editor).update(Field.HOME_PAGE, SCORE, HOMEPAGE);
-            verify(editor).update(Field.ATTRIBUTION, SCORE, ATTRIBUTION);
-            verify(editor).update(Field.DECLARED_LICENSE, SCORE, DECLARED_LICENSE);
-            verify(editor).update(Field.DETECTED_LICENSES, SCORE, List.of(DETECTED_LICENSE));
-            verify(editor).update(Field.SHA1, SCORE, SHA1);
-            verify(editor).update(Field.SHA256, SCORE, SHA256);
+            verify(editor).update(Field.TITLE, TRUST, TITLE);
+            verify(editor).update(Field.DESCRIPTION, TRUST, DESCRIPTION);
+            verify(editor).update(Field.SOURCE_LOCATION, TRUST, SOURCE_LOCATION);
+            verify(editor).update(Field.DOWNLOAD_LOCATION, TRUST, DOWNLOAD_LOCATION);
+            verify(editor).update(Field.HOME_PAGE, TRUST, HOMEPAGE);
+            verify(editor).update(Field.ATTRIBUTION, TRUST, ATTRIBUTION);
+            verify(editor).update(Field.DECLARED_LICENSE, TRUST, DECLARED_LICENSE);
+            verify(editor).update(Field.DETECTED_LICENSES, TRUST, List.of(DETECTED_LICENSE));
+            verify(editor).update(Field.SHA1, TRUST, SHA1);
+            verify(editor).update(Field.SHA256, TRUST, SHA256);
         }
 
         @Test

--- a/src/test/java/com/philips/research/bombase/core/meta/MetaInteractorTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/MetaInteractorTest.java
@@ -80,7 +80,7 @@ class MetaInteractorTest {
 
         @Test
         void queriesPackageDetails() {
-            editor.update(Field.TITLE, 100, TITLE);
+            editor.update(Field.TITLE, Trust.TRUTH, TITLE);
 
             final var values = interactor.getAttributes(PURL);
 
@@ -109,7 +109,7 @@ class MetaInteractorTest {
 
         @Test
         void updatesAttributeValue() {
-            editor.update(Field.TITLE, 99, "Removed");
+            editor.update(Field.TITLE, Trust.CERTAIN, "Removed");
 
             interactor.setAttributes(PURL, Map.of("title", TITLE));
 

--- a/src/test/java/com/philips/research/bombase/core/meta/registry/MetaRegistryTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/registry/MetaRegistryTest.java
@@ -28,7 +28,7 @@ class MetaRegistryTest {
     private static final PackageURL PURL = toPurl("pkg:" + TYPE + "/" + NAME + "@" + VERSION);
     private static final Field FIELD = Field.TITLE;
     private static final String VALUE = "Value";
-    private static final int SCORE = 50;
+    private static final Trust TRUST = Trust.PROBABLY;
 
     final MetaStore store = mock(MetaStore.class);
     final MetaRegistry registry = new MetaRegistry(store, new QueuedTaskRunner(store));
@@ -51,17 +51,17 @@ class MetaRegistryTest {
 
     @Test
     void readsPackageFieldValues() {
-        registry.edit(PURL, pkg -> pkg.update(FIELD, SCORE, VALUE));
+        registry.edit(PURL, pkg -> pkg.update(FIELD, TRUST, VALUE));
 
         final var values = registry.getAttributeValues(PURL).orElseThrow();
 
-        assertThat(values.get(FIELD).getScore()).isEqualTo(SCORE);
+        assertThat(values.get(FIELD).getScore()).isEqualTo(TRUST.getScore());
         assertThat(values.get(FIELD).getValue()).isEqualTo(Optional.of(VALUE));
     }
 
     @Test
     void editsPackageFields() {
-        registry.edit(PURL, editor -> editor.update(FIELD, SCORE, VALUE));
+        registry.edit(PURL, editor -> editor.update(FIELD, TRUST, VALUE));
 
         assertThat(pkg.getAttributeFor(FIELD).orElseThrow().getValue()).contains(VALUE);
     }
@@ -85,7 +85,7 @@ class MetaRegistryTest {
 
         @Test
         void notifiesListeners_modifiedFields() {
-            registry.edit(PURL, pkg -> pkg.update(FIELD, SCORE, VALUE));
+            registry.edit(PURL, pkg -> pkg.update(FIELD, TRUST, VALUE));
 
             verify(listener).onUpdated(PURL, Set.of(FIELD), Map.of(FIELD, VALUE));
         }
@@ -103,7 +103,7 @@ class MetaRegistryTest {
             //noinspection unchecked
             when(listener.onUpdated(any(), any(), any())).thenReturn(Optional.of(task));
 
-            registry.edit(PURL, editor -> editor.update(FIELD, SCORE, VALUE));
+            registry.edit(PURL, editor -> editor.update(FIELD, TRUST, VALUE));
 
             //noinspection unchecked
             verify(task).accept(any(PackageAttributeEditor.class));
@@ -119,16 +119,16 @@ class MetaRegistryTest {
             doAnswer(param -> {
                 final PackageAttributeEditor editor = param.getArgument(0);
                 final var offset = counter.incrementAndGet();
-                if (offset < 10) {
-                    editor.update(FIELD, SCORE + offset, VALUE + offset);
+                if (offset < Trust.values().length) {
+                    editor.update(FIELD, Trust.values()[offset], VALUE + offset);
                 }
                 return null;
             }).when(task).accept(any());
 
-            registry.edit(PURL, editor -> editor.update(FIELD, SCORE, VALUE));
+            registry.edit(PURL, editor -> editor.update(FIELD, TRUST, VALUE));
 
             //noinspection unchecked
-            verify(task, times(10)).accept(any());
+            verify(task, times(Trust.values().length)).accept(any());
         }
     }
 }

--- a/src/test/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditorTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditorTest.java
@@ -18,7 +18,7 @@ class PackageAttributeEditorTest {
     private static final PackageURL PURL = toPurl("pkg:type/ns/name@version");
     private static final String TITLE = "Title";
     private static final String DESCRIPTION = "Description";
-    private static final int SCORE = 50;
+    private static final Trust TRUST = Trust.LIKELY;
 
     private final Package pkg = new Package(PURL);
     private final PackageAttributeEditor editor = new PackageAttributeEditor(pkg);
@@ -39,10 +39,10 @@ class PackageAttributeEditorTest {
     @Test
     void tracksFieldValues() {
         final var attr = new Attribute(Field.TITLE);
-        attr.setValue(SCORE, TITLE);
+        attr.setValue(TRUST, TITLE);
         pkg.add(attr);
 
-        editor.update(Field.DESCRIPTION, SCORE, DESCRIPTION);
+        editor.update(Field.DESCRIPTION, TRUST, DESCRIPTION);
 
         assertThat(editor.get(Field.TITLE)).contains(TITLE);
         assertThat(editor.get(Field.DESCRIPTION)).contains(DESCRIPTION);
@@ -50,9 +50,8 @@ class PackageAttributeEditorTest {
 
     @Test
     void tracksModifiedFields() {
-        editor.update(Field.DOWNLOAD_LOCATION, SCORE, null);
-        editor.update(Field.SOURCE_LOCATION, 0, URI.create("http://example.com/source"));
-        editor.update(Field.TITLE, SCORE, TITLE);
+        editor.update(Field.DOWNLOAD_LOCATION, TRUST, null);
+        editor.update(Field.TITLE, TRUST, TITLE);
 
         assertThat(editor.getModifiedFields()).containsExactly(Field.TITLE);
         assertThat(editor.isModified()).isTrue();
@@ -60,7 +59,7 @@ class PackageAttributeEditorTest {
 
     @Test
     void createsNewAttribute() {
-        editor.update(Field.TITLE, SCORE, TITLE);
+        editor.update(Field.TITLE, TRUST, TITLE);
 
         assertThat(pkg.getAttributeFor(Field.TITLE).orElseThrow().getValue()).contains(TITLE);
         assertThat(editor.isModified()).isTrue();
@@ -68,12 +67,12 @@ class PackageAttributeEditorTest {
 
     @Test
     void snapshotsValues() {
-        pkg.add(new Attribute(Field.SHA1));
-        editor.update(Field.TITLE, SCORE, TITLE);
+        pkg.add(new Attribute<>(Field.SHA1));
+        editor.update(Field.TITLE, TRUST, TITLE);
         final var snapshot = editor.getValues();
 
-        editor.update(Field.TITLE, SCORE + 1, "Changed");
-        editor.update(Field.DESCRIPTION, SCORE, "Created");
+        editor.update(Field.TITLE, Trust.values()[TRUST.ordinal() + 1], "Changed");
+        editor.update(Field.DESCRIPTION, TRUST, "Created");
 
         assertThat(snapshot).isEqualTo(Map.of(Field.TITLE, TITLE));
     }

--- a/src/test/java/com/philips/research/bombase/core/meta/registry/TrustTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/registry/TrustTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.meta.registry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TrustTest {
+    @Test
+    void mapsToPercentageScore() {
+        for (var trust : Trust.values()) {
+            assertThat(trust.getScore()).isBetween(1, 100);
+        }
+    }
+
+    @Test
+    void mapsToIncreasingScores() {
+        var previous = 0;
+        for (var trust : Trust.values()) {
+            assertThat(trust.getScore()).isGreaterThan(previous);
+            previous = trust.getScore();
+        }
+    }
+}

--- a/src/test/java/com/philips/research/bombase/core/source_scan/domain/SourceLicensesHarvesterTest.java
+++ b/src/test/java/com/philips/research/bombase/core/source_scan/domain/SourceLicensesHarvesterTest.java
@@ -11,6 +11,7 @@ import com.philips.research.bombase.core.downloader.DownloadService;
 import com.philips.research.bombase.core.meta.registry.Field;
 import com.philips.research.bombase.core.meta.registry.MetaRegistry;
 import com.philips.research.bombase.core.meta.registry.PackageAttributeEditor;
+import com.philips.research.bombase.core.meta.registry.Trust;
 import com.philips.research.bombase.core.scanner.ScannerService;
 import com.philips.research.bombase.core.scanner.ScannerService.LicenseResult;
 import com.philips.research.bombase.core.scanner.ScannerService.ScanResult;
@@ -101,23 +102,7 @@ class SourceLicensesHarvesterTest {
 
             task.accept(pkg);
 
-            verify(pkg).update(Field.DETECTED_LICENSES, SourceLicensesHarvester.MAX_SCORE, List.of(LICENSE1, LICENSE2));
-        }
-
-        @Test
-        void weightsDetectedLicenses() {
-            LicenseResult license1 = mock(LicenseResult.class);
-            when(license1.getScore()).thenReturn(50);
-            when(license1.getConfirmations()).thenReturn(400);
-            LicenseResult license2 = mock(LicenseResult.class);
-            when(license2.getScore()).thenReturn(80);
-            when(license2.getConfirmations()).thenReturn(200);
-            when(scanResult.getLicenses()).thenReturn(List.of(license1, license2));
-
-            task.accept(pkg);
-
-            final var expected = Math.round((50f * 400 + 80f * 200) / ((400 + 200) * 100) * SourceLicensesHarvester.MAX_SCORE);
-            verify(pkg).update(eq(Field.DETECTED_LICENSES), eq(expected), anyList());
+            verify(pkg).update(Field.DETECTED_LICENSES, Trust.PROBABLY, List.of(LICENSE1, LICENSE2));
         }
     }
 }


### PR DESCRIPTION
Trust is now specified by an enum, which is internally converted to scores to
priorize (and persist) values.

Also tried to improve the relative reliability between package management repositories and ClearlyDefined.