### PR TITLE
Feature/license from url

### DIFF
--- a/src/main/java/com/philips/research/bombase/ConfigProperties.java
+++ b/src/main/java/com/philips/research/bombase/ConfigProperties.java
@@ -15,16 +15,16 @@ public class ConfigProperties {
     public boolean isScanLicenses() {
         return scanLicenses;
     }
-    
-    public boolean harvestClearlyDefined() {
-        return harvestClearlyDefined;
-    }
 
     public ConfigProperties setScanLicenses(boolean scanLicenses) {
         this.scanLicenses = scanLicenses;
         return this;
     }
-    
+
+    public boolean harvestClearlyDefined() {
+        return harvestClearlyDefined;
+    }
+
     public ConfigProperties setHarvestClearlyDefined(boolean harvestClearlyDefined) {
         this.harvestClearlyDefined = harvestClearlyDefined;
         return this;

--- a/src/main/java/com/philips/research/bombase/controller/JacksonConfiguration.java
+++ b/src/main/java/com/philips/research/bombase/controller/JacksonConfiguration.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +28,7 @@ public class JacksonConfiguration {
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, true)
                 .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.NON_PRIVATE)
-                .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
                 .registerModule(new JavaTimeModule());
     }
 }

--- a/src/main/java/com/philips/research/bombase/core/downloader/DownloadService.java
+++ b/src/main/java/com/philips/research/bombase/core/downloader/DownloadService.java
@@ -7,7 +7,7 @@ package com.philips.research.bombase.core.downloader;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Makes files available in a directory local to this machine for processing.
@@ -18,8 +18,9 @@ public interface DownloadService {
     /**
      * Downloads a file or directory structure from an online location.
      *
-     * @param location download location
-     * @param callback lambda to invoke with the downloaded base directory
+     * @param location  download location
+     * @param operation lambda to invoke with the downloaded base directory
+     * @return the result of the operation
      */
-    void download(URI location, Consumer<Path> callback);
+    <T> T download(URI location, Function<Path, T> operation);
 }

--- a/src/main/java/com/philips/research/bombase/core/downloader/domain/AnonymousVcsHandler.java
+++ b/src/main/java/com/philips/research/bombase/core/downloader/domain/AnonymousVcsHandler.java
@@ -120,7 +120,7 @@ class AnonymousVcsHandler implements VcsHandler {
             }
 
             uri = redirection(uri, urlConnection);
-            urlConnection = (HttpU)
+            urlConnection = (HttpURLConnection) uri.toURL().openConnection();
         }
     }
 

--- a/src/main/java/com/philips/research/bombase/core/downloader/domain/AnonymousVcsHandler.java
+++ b/src/main/java/com/philips/research/bombase/core/downloader/domain/AnonymousVcsHandler.java
@@ -67,7 +67,6 @@ class AnonymousVcsHandler implements VcsHandler {
         } catch (IOException e) {
             throw new DownloadException("File download failed from " + fromUri, e);
         }
-        System.out.println("File has size: " + target.length());
     }
 
     private String filenameFor(URI uri) {
@@ -121,7 +120,7 @@ class AnonymousVcsHandler implements VcsHandler {
             }
 
             uri = redirection(uri, urlConnection);
-            urlConnection = (HttpURLConnection) uri.toURL().openConnection();
+            urlConnection = (HttpU)
         }
     }
 

--- a/src/main/java/com/philips/research/bombase/core/downloader/domain/AnonymousVcsHandler.java
+++ b/src/main/java/com/philips/research/bombase/core/downloader/domain/AnonymousVcsHandler.java
@@ -14,13 +14,19 @@ import pl.tlinkowski.annotation.basic.NullOr;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Download handler for file and internet resources.
@@ -54,14 +60,14 @@ class AnonymousVcsHandler implements VcsHandler {
     private void copyFile(File target, URI fromUri) {
         LOG.info("Download file from {} to {}", fromUri, target);
         try (FileOutputStream out = new FileOutputStream(target)) {
-            final var url = fromUri.toURL();
-            ReadableByteChannel inChannel = Channels.newChannel(url.openStream());
+            ReadableByteChannel inChannel = Channels.newChannel(openStream(fromUri));
             FileChannel outChannel = out.getChannel();
             outChannel.transferFrom(inChannel, 0, Long.MAX_VALUE);
             inChannel.close();
         } catch (IOException e) {
             throw new DownloadException("File download failed from " + fromUri, e);
         }
+        System.out.println("File has size: " + target.length());
     }
 
     private String filenameFor(URI uri) {
@@ -85,5 +91,43 @@ class AnonymousVcsHandler implements VcsHandler {
                 .filter(File::isDirectory)
                 .findFirst().orElse(baseDir)
                 .toPath();
+    }
+
+    /**
+     * Workaround to redirect from HTTP to HTTPS.
+     *
+     * @see <a href="https://stackoverflow.com/questions/1884230/httpurlconnection-doesnt-follow-redirect-from-http-to-https">This explanation</a>
+     */
+    private InputStream openStream(URI uri) throws IOException {
+        final var connection = uri.toURL().openConnection();
+        if (!(connection instanceof HttpURLConnection)) {
+            return connection.getInputStream();
+        }
+
+        Map<URI, Integer> visited = new HashMap<>();
+        var urlConnection = (HttpURLConnection) connection;
+        while (true) {
+            final int times = visited.compute(uri, (key, count) -> count == null ? 1 : count + 1);
+            if (times > 3) {
+                throw new IOException("Aborted: Stuck in redirect loop");
+            }
+
+            urlConnection.setConnectTimeout(15000);
+            urlConnection.setReadTimeout(15000);
+            urlConnection.setInstanceFollowRedirects(false);   // We handle redirects ourselves
+            urlConnection.setRequestProperty("User-Agent", "Mozilla/5.0...");
+            if (urlConnection.getResponseCode() != 301) {
+                return urlConnection.getInputStream();
+            }
+
+            uri = redirection(uri, urlConnection);
+            urlConnection = (HttpURLConnection) uri.toURL().openConnection();
+        }
+    }
+
+    private URI redirection(URI uri, HttpURLConnection conn) {
+        final var location = conn.getHeaderField("Location");
+        final var url = URLDecoder.decode(location, StandardCharsets.UTF_8);
+        return uri.resolve(url);
     }
 }

--- a/src/main/java/com/philips/research/bombase/core/downloader/domain/DownloadInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/downloader/domain/DownloadInteractor.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import javax.annotation.PreDestroy;
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 @Service
 public class DownloadInteractor implements DownloadService {
@@ -29,10 +29,10 @@ public class DownloadInteractor implements DownloadService {
     }
 
     @Override
-    public void download(URI location, Consumer<Path> callback) {
+    public <T> T download(URI location, Function<Path, T> operation) {
         final var directory = cache.obtain(location);
         try {
-            callback.accept(directory);
+            return operation.apply(directory);
         } finally {
             cache.release(location);
         }

--- a/src/main/java/com/philips/research/bombase/core/license/domain/LicenseCleaner.java
+++ b/src/main/java/com/philips/research/bombase/core/license/domain/LicenseCleaner.java
@@ -9,7 +9,6 @@ import com.github.packageurl.PackageURL;
 import com.philips.research.bombase.core.meta.registry.Field;
 import com.philips.research.bombase.core.meta.registry.MetaRegistry;
 import com.philips.research.bombase.core.meta.registry.PackageAttributeEditor;
-import com.philips.research.bombase.core.meta.registry.Trust;
 import com.philips.research.bombase.core.scanner.ScannerService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -49,7 +48,7 @@ public class LicenseCleaner implements MetaRegistry.PackageListener {
                 .map(lic -> (String) lic)
                 .map(lic -> URL_PATTERN.matcher(lic)
                         .replaceAll(result -> licenseFor(result.group())))
-                .ifPresent(lic -> editor.update(Field.DECLARED_LICENSE, Trust.PROBABLY, lic));
+                .ifPresent(lic -> editor.update(Field.DECLARED_LICENSE, editor.trust(Field.DECLARED_LICENSE), lic));
     }
 
     private String licenseFor(String url) {

--- a/src/main/java/com/philips/research/bombase/core/license/domain/LicenseCleaner.java
+++ b/src/main/java/com/philips/research/bombase/core/license/domain/LicenseCleaner.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.license.domain;
+
+import com.github.packageurl.PackageURL;
+import com.philips.research.bombase.core.meta.registry.Field;
+import com.philips.research.bombase.core.meta.registry.MetaRegistry;
+import com.philips.research.bombase.core.meta.registry.PackageAttributeEditor;
+import com.philips.research.bombase.core.meta.registry.Trust;
+import com.philips.research.bombase.core.scanner.ScannerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+/**
+ * Cleans up updated license values.
+ */
+@Service
+public class LicenseCleaner implements MetaRegistry.PackageListener {
+    private static final Pattern URL_PATTERN = Pattern.compile("https?:\\S+");
+
+    private final ScannerService scanner;
+
+    @Autowired
+    public LicenseCleaner(ScannerService scanner) {
+        this.scanner = scanner;
+    }
+
+    @Override
+    public Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, Object> values) {
+        final var current = (String) values.getOrDefault(Field.DECLARED_LICENSE, "");
+        if (!updated.contains(Field.DECLARED_LICENSE) || !URL_PATTERN.matcher(current).find()) {
+            return Optional.empty();
+        }
+        return Optional.of(this::clean);
+    }
+
+    void clean(PackageAttributeEditor editor) {
+        editor.get(Field.DECLARED_LICENSE)
+                .map(lic -> (String) lic)
+                .map(lic -> URL_PATTERN.matcher(lic)
+                        .replaceAll(result -> licenseFor(result.group())))
+                .ifPresent(lic -> editor.update(Field.DECLARED_LICENSE, Trust.PROBABLY, lic));
+    }
+
+    private String licenseFor(String url) {
+        try {
+            final var licenses = scanner.scanLicenses(URI.create(url));
+            return !licenses.isEmpty() ? licenses.get(0) : url;
+        } catch (Exception e) {
+            return url;
+        }
+    }
+}

--- a/src/main/java/com/philips/research/bombase/core/license/domain/package-info.java
+++ b/src/main/java/com/philips/research/bombase/core/license/domain/package-info.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+@pl.tlinkowski.annotation.basic.NonNullPackage
+package com.philips.research.bombase.core.license.domain;

--- a/src/main/java/com/philips/research/bombase/core/license/package-info.java
+++ b/src/main/java/com/philips/research/bombase/core/license/package-info.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+@pl.tlinkowski.annotation.basic.NonNullPackage
+package com.philips.research.bombase.core.license;

--- a/src/main/java/com/philips/research/bombase/core/maven/domain/PomXml.java
+++ b/src/main/java/com/philips/research/bombase/core/maven/domain/PomXml.java
@@ -75,7 +75,7 @@ class PomXml implements PackageMetadata {
     }
 
     private @NullOr String licenseOf(ReferenceXml xml) {
-        return (xml.name != null) ? xml.name : xml.url;
+        return (xml.url != null) ? xml.url : xml.name;
     }
 
     @Override

--- a/src/main/java/com/philips/research/bombase/core/meta/AbstractRepoHarvester.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/AbstractRepoHarvester.java
@@ -30,7 +30,7 @@ public abstract class AbstractRepoHarvester implements MetaRegistry.PackageListe
     }
 
     @Override
-    public Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, ?> values) {
+    public Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, Object> values) {
         if (!isSupportedType(purl.getType()) || !updated.isEmpty()) {
             return Optional.empty();
         }

--- a/src/main/java/com/philips/research/bombase/core/meta/MetaInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/MetaInteractor.java
@@ -10,6 +10,7 @@ import com.philips.research.bombase.ConfigProperties;
 import com.philips.research.bombase.core.MetaService;
 import com.philips.research.bombase.core.UnknownPackageException;
 import com.philips.research.bombase.core.clearlydefined.domain.ClearlyDefinedHarvester;
+import com.philips.research.bombase.core.license.domain.LicenseCleaner;
 import com.philips.research.bombase.core.maven.domain.MavenHarvester;
 import com.philips.research.bombase.core.meta.registry.Field;
 import com.philips.research.bombase.core.meta.registry.MetaRegistry;
@@ -50,11 +51,12 @@ public class MetaInteractor implements MetaService {
         final var properties = context.getBean(ConfigProperties.class);
 
         if (properties.harvestClearlyDefined()) {
-          installListener(ClearlyDefinedHarvester.class);
+            installListener(ClearlyDefinedHarvester.class);
         }
         installListener(PyPiHarvester.class);
         installListener(NpmHarvester.class);
         installListener(MavenHarvester.class);
+        installListener(LicenseCleaner.class);
         if (properties.isScanLicenses()) {
             installListener(SourceLicensesHarvester.class);
         }

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/MetaRegistry.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/MetaRegistry.java
@@ -101,6 +101,6 @@ public class MetaRegistry {
          * @param values  current package metadata
          * @return (optional) operation to queue for execution
          */
-        Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, ?> values);
+        Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, Object> values);
     }
 }

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/Package.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/Package.java
@@ -34,7 +34,7 @@ public class Package {
         return lastUpdated;
     }
 
-    public Attribute<?> add(Attribute<?> attribute) {
+    public <T> Attribute<T> add(Attribute<T> attribute) {
         if (attributes.contains(attribute)) {
             throw new IllegalArgumentException("The " + attribute.getField().name() + " attribute already exists in package " + purl);
         }

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditor.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditor.java
@@ -49,6 +49,16 @@ public class PackageAttributeEditor {
     }
 
     /**
+     * @return trust of the current value for the indicated field
+     */
+    public Trust trust(Field field) {
+        return pkg.getAttributeFor(field)
+                .map(Attribute::getScore)
+                .map(Trust::of)
+                .orElse(Trust.NONE);
+    }
+
+    /**
      * Optionally updates the value of a field based on its relative trust.
      *
      * @param field the metadata attribute to overwrite
@@ -67,13 +77,13 @@ public class PackageAttributeEditor {
         return this;
     }
 
-    private Attribute getOrCreateAttr(Field field) {
-        return pkg.getAttributeFor(field).orElseGet(() -> createAttribute(field));
+    private <T> Attribute<T> getOrCreateAttr(Field field) {
+        return pkg.<T>getAttributeFor(field).orElseGet(() -> createAttribute(field));
     }
 
     // Necessary to allow generation of a tracked persistence entity.
-    protected Attribute createAttribute(Field field) {
-        return pkg.add(new Attribute(field));
+    protected <T> Attribute<T> createAttribute(Field field) {
+        return pkg.add(new Attribute<>(field));
     }
 
     /**

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/Trust.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/Trust.java
@@ -6,6 +6,7 @@
 package com.philips.research.bombase.core.meta.registry;
 
 public enum Trust {
+    NONE(0),
     MAYBE(10),
     PROBABLY(60),
     LIKELY(70),
@@ -16,6 +17,15 @@ public enum Trust {
 
     Trust(int score) {
         this.score = score;
+    }
+
+    static Trust of(int score) {
+        for (var trust : Trust.values()) {
+            if (trust.getScore() >= score) {
+                return trust;
+            }
+        }
+        return Trust.TRUTH;
     }
 
     int getScore() {

--- a/src/main/java/com/philips/research/bombase/core/scanner/ScannerService.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/ScannerService.java
@@ -6,6 +6,7 @@
 package com.philips.research.bombase.core.scanner;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -16,7 +17,13 @@ public interface ScannerService {
      * @param directory location of the files
      * @return results of the scan
      */
+    //TODO Not sure if we should scan files instead of an URI
     ScanResult scan(Path directory);
+
+    /**
+     * @return list of licenses detected in the content indicated by the URI
+     */
+    List<String> scanLicenses(URI uri);
 
     interface ScanResult {
         List<LicenseResult> getLicenses();

--- a/src/main/java/com/philips/research/bombase/core/scanner/domain/Detection.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/domain/Detection.java
@@ -17,17 +17,16 @@ import java.util.Objects;
  * Keeps track of the location with the highest percentage match, and the number of matches found.
  */
 public class Detection implements ScannerService.LicenseResult {
-    private static final File NO_FILE = new File("?");
     private static final String[] UNLIKELY = {"test", "sample", "docs", "demo", "tutorial", "changelog"};
 
     private final String expression;
 
     private int score;
     private int confirmations;
-    private File filePath = NO_FILE;
+    private File filePath;
     private int startLine;
     private int endLine;
-    private boolean ignored = true;
+    private boolean ignored;
 
     public Detection(String expression, int score, File file, int startLine, int endLine) {
         this.expression = expression;

--- a/src/main/java/com/philips/research/bombase/core/scanner/domain/ScanCodeJson.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/domain/ScanCodeJson.java
@@ -98,7 +98,7 @@ class FileJson {
                 return key;
             }
 
-            score = Math.min(score, (int) lic.score);
+            score = Math.min(score, (int) lic.effectiveScore());
             startLine = Math.min(startLine, lic.startLine);
             endLine = Math.max(endLine, lic.endLine);
             return lic.getIdentifier();
@@ -109,8 +109,7 @@ class FileJson {
 @JsonIgnoreProperties(ignoreUnknown = true)
 class LicenseJson {
     @JsonProperty("key")
-    @NullOr
-    String key;
+    @NullOr String key;
     @JsonProperty("score")
     double score;
     @JsonProperty("start_line")
@@ -135,6 +134,12 @@ class LicenseJson {
     String getIdentifier() {
         assert spdx != null || key != null;
         return (spdx != null) ? spdx : key;
+    }
+
+    double effectiveScore() {
+        return getIdentifier().contains("LicenseRef")
+                ? 0.8f * score
+                : score;
     }
 
     public int lines() {

--- a/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
@@ -44,7 +44,6 @@ public class ScannerInteractor implements ScannerService {
         final var licenses = downloader.download(uri, scanner::scan)
                 .getLicenses().stream()
                 .sorted((l, r) -> Integer.compare(r.getScore(), l.getScore()))
-                .peek(lic -> System.out.println(lic.getExpression() + " [" + lic.getScore() + "%]"))
                 .map(LicenseResult::getExpression)
                 .collect(Collectors.toList());
         LOG.info("Scanned {} =>{}", uri, licenses);

--- a/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
@@ -7,6 +7,8 @@ package com.philips.research.bombase.core.scanner.domain;
 
 import com.philips.research.bombase.core.downloader.DownloadService;
 import com.philips.research.bombase.core.scanner.ScannerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +19,8 @@ import java.util.stream.Collectors;
 
 @Service
 public class ScannerInteractor implements ScannerService {
+    private static final Logger LOG = LoggerFactory.getLogger(ScannerInteractor.class);
+
     private final DownloadService downloader;
     private final ScanCodeScanner scanner;
 
@@ -37,9 +41,13 @@ public class ScannerInteractor implements ScannerService {
 
     @Override
     public List<String> scanLicenses(URI uri) {
-        return downloader.download(uri, scanner::scan)
+        final var licenses = downloader.download(uri, scanner::scan)
                 .getLicenses().stream()
+                .sorted((l, r) -> Integer.compare(r.getScore(), l.getScore()))
+                .peek(lic -> System.out.println(lic.getExpression() + " [" + lic.getScore() + "%]"))
                 .map(LicenseResult::getExpression)
                 .collect(Collectors.toList());
+        LOG.info("Scanned {} =>{}", uri, licenses);
+        return licenses;
     }
 }

--- a/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
@@ -5,25 +5,41 @@
 
 package com.philips.research.bombase.core.scanner.domain;
 
+import com.philips.research.bombase.core.downloader.DownloadService;
 import com.philips.research.bombase.core.scanner.ScannerService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.net.URI;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ScannerInteractor implements ScannerService {
+    private final DownloadService downloader;
     private final ScanCodeScanner scanner;
 
-    public ScannerInteractor() {
-        this(new ScanCodeScanner());
+    @Autowired
+    public ScannerInteractor(DownloadService downloader) {
+        this(downloader, new ScanCodeScanner());
     }
 
-    ScannerInteractor(ScanCodeScanner scanner) {
+    ScannerInteractor(DownloadService downloader, ScanCodeScanner scanner) {
+        this.downloader = downloader;
         this.scanner = scanner;
     }
 
     @Override
     public ScanResult scan(Path directory) {
         return scanner.scan(directory);
+    }
+
+    @Override
+    public List<String> scanLicenses(URI uri) {
+        return downloader.download(uri, scanner::scan)
+                .getLicenses().stream()
+                .map(LicenseResult::getExpression)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/philips/research/bombase/core/downloader/domain/DownloadInteractorTest.java
+++ b/src/test/java/com/philips/research/bombase/core/downloader/domain/DownloadInteractorTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -23,9 +22,7 @@ class DownloadInteractorTest {
 
     @Test
     void downloadsFromUri() {
-        final var found = new AtomicBoolean(false);
-
-        interactor.download(FILE_URI, path -> found.set(path.toFile().exists()));
+        final var found = interactor.download(FILE_URI, path -> path.toFile().exists());
 
         assertThat(found).isTrue();
     }

--- a/src/test/java/com/philips/research/bombase/core/license/domain/LicenseCleanerTest.java
+++ b/src/test/java/com/philips/research/bombase/core/license/domain/LicenseCleanerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.license.domain;
+
+import com.github.packageurl.PackageURL;
+import com.philips.research.bombase.core.downloader.DownloadService;
+import com.philips.research.bombase.core.meta.registry.Field;
+import com.philips.research.bombase.core.meta.registry.Package;
+import com.philips.research.bombase.core.meta.registry.PackageAttributeEditor;
+import com.philips.research.bombase.core.meta.registry.Trust;
+import com.philips.research.bombase.core.scanner.ScannerException;
+import com.philips.research.bombase.core.scanner.ScannerService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class LicenseCleanerTest {
+    private static final String LICENSE_URL = "https://example.com/license";
+    private static final PackageURL PURL = purlOf("pkg:generic/name@version");
+
+    private final DownloadService downloader = mock(DownloadService.class);
+    private final ScannerService scanner = mock(ScannerService.class);
+    private final LicenseCleaner cleaner = new LicenseCleaner(scanner);
+
+    private static PackageURL purlOf(String purl) {
+        try {
+            return new PackageURL(purl);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create Package URL");
+        }
+    }
+
+    @Test
+    void createsTaskOnDeclaredLicenseUpdateWithURL() {
+        final var task = cleaner.onUpdated(PURL, Set.of(Field.DECLARED_LICENSE), Map.of(Field.DECLARED_LICENSE, LICENSE_URL));
+
+        assertThat(task).isNotEmpty();
+    }
+
+    @Test
+    void noTask_noLicenseUpdate() {
+        final var allOtherFields = Arrays.stream(Field.values())
+                .filter(field -> field != Field.DECLARED_LICENSE)
+                .collect(Collectors.toSet());
+
+        final var task = cleaner.onUpdated(PURL, allOtherFields, Map.of(Field.DECLARED_LICENSE, LICENSE_URL));
+
+        assertThat(task).isEmpty();
+    }
+
+    @Test
+    void noTask_noUrlInLicenseUpdate() {
+        final var task = cleaner.onUpdated(PURL, Set.of(Field.DECLARED_LICENSE), Map.of(Field.DECLARED_LICENSE, "No URL here"));
+
+        assertThat(task).isEmpty();
+    }
+
+    @Nested
+    class LicenseValueUpdate {
+        private static final String LICENSE = "License";
+        private static final String PREFIX = "Prefix ";
+        private static final String POSTFIX = " Postfix";
+        private final Trust TRUST = Trust.PROBABLY;
+
+        private final Package pkg = new Package(PURL);
+        private final PackageAttributeEditor editor = spy(new PackageAttributeEditor(pkg));
+        private final Consumer<PackageAttributeEditor> task = cleaner
+                .onUpdated(PURL, Set.of(Field.DECLARED_LICENSE), Map.of(Field.DECLARED_LICENSE, LICENSE_URL)).orElseThrow();
+
+        @Test
+        void replacesUrlByScanningLicenses() {
+            editor.update(Field.DECLARED_LICENSE, TRUST, PREFIX + LICENSE_URL + POSTFIX);
+            when(scanner.scanLicenses(URI.create(LICENSE_URL))).thenReturn(List.of(LICENSE));
+
+            task.accept(editor);
+
+            verify(editor).update(Field.DECLARED_LICENSE, TRUST, PREFIX + LICENSE + POSTFIX);
+        }
+
+        @Test
+        void replacesMultipleUrls() {
+            editor.update(Field.DECLARED_LICENSE, TRUST, LICENSE_URL + " AND " + LICENSE_URL);
+            when(scanner.scanLicenses(URI.create(LICENSE_URL))).thenReturn(List.of(LICENSE));
+
+            task.accept(editor);
+
+            verify(editor).update(Field.DECLARED_LICENSE, TRUST, LICENSE + " AND " + LICENSE);
+        }
+
+        @Test
+        void ignoresFailedLicenseScans() {
+            editor.update(Field.DECLARED_LICENSE, TRUST, LICENSE_URL);
+            when(scanner.scanLicenses(URI.create(LICENSE_URL))).thenThrow(new ScannerException("Test"));
+
+            task.accept(editor);
+
+            verify(editor, times(2)).update(Field.DECLARED_LICENSE, TRUST, LICENSE_URL);
+        }
+
+        @Test
+        void ignoresScansWithoutLicenseResult() {
+            editor.update(Field.DECLARED_LICENSE, TRUST, LICENSE_URL);
+            when(scanner.scanLicenses(URI.create(LICENSE_URL))).thenReturn(List.of());
+
+            task.accept(editor);
+
+            verify(editor, times(2)).update(Field.DECLARED_LICENSE, TRUST, LICENSE_URL);
+        }
+    }
+}

--- a/src/test/java/com/philips/research/bombase/core/maven/domain/PomXmlTest.java
+++ b/src/test/java/com/philips/research/bombase/core/maven/domain/PomXmlTest.java
@@ -39,11 +39,11 @@ class PomXmlTest {
         }
 
         @Test
-        void prefersNameOverUrl() {
+        void prefersUrlOverName() {
             final var xml = new PomXml();
             xml.licenses = List.of(reference(LICENSE1, URI.create(LICENSE_URL)));
 
-            assertThat(xml.getDeclaredLicense()).contains(LICENSE1);
+            assertThat(xml.getDeclaredLicense()).contains(LICENSE_URL);
         }
 
         @Test

--- a/src/test/java/com/philips/research/bombase/core/meta/registry/MetaRegistryTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/registry/MetaRegistryTest.java
@@ -111,7 +111,7 @@ class MetaRegistryTest {
 
         @Test
         void cascadesEditsToListenersUntilNoMoreEditsAreMade() {
-            final var counter = new AtomicInteger();
+            final var counter = new AtomicInteger(1);
             final var task = mock(Consumer.class);
             //noinspection unchecked
             when(listener.onUpdated(any(), any(), any())).thenReturn(Optional.of(task));
@@ -128,7 +128,7 @@ class MetaRegistryTest {
             registry.edit(PURL, editor -> editor.update(FIELD, TRUST, VALUE));
 
             //noinspection unchecked
-            verify(task, times(Trust.values().length)).accept(any());
+            verify(task, times(Trust.values().length - 1)).accept(any());
         }
     }
 }

--- a/src/test/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditorTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditorTest.java
@@ -9,7 +9,6 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import org.junit.jupiter.api.Test;
 
-import java.net.URI;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditorTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditorTest.java
@@ -75,4 +75,17 @@ class PackageAttributeEditorTest {
 
         assertThat(snapshot).isEqualTo(Map.of(Field.TITLE, TITLE));
     }
+
+    @Test
+    void indicatesTrustForField() {
+        pkg.add(new Attribute<>(Field.TITLE));
+        editor.update(Field.TITLE, TRUST, TITLE);
+
+        assertThat(editor.trust(Field.TITLE)).isEqualTo(TRUST);
+    }
+
+    @Test
+    void minimalTrustForFieldWithoutValue() {
+        assertThat(editor.trust(Field.TITLE)).isEqualTo(Trust.NONE);
+    }
 }

--- a/src/test/java/com/philips/research/bombase/core/meta/registry/TrustTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/registry/TrustTest.java
@@ -13,16 +13,35 @@ class TrustTest {
     @Test
     void mapsToPercentageScore() {
         for (var trust : Trust.values()) {
-            assertThat(trust.getScore()).isBetween(1, 100);
+            assertThat(trust.getScore()).isBetween(0, 100);
         }
     }
 
     @Test
     void mapsToIncreasingScores() {
-        var previous = 0;
+        var previous = -1;
         for (var trust : Trust.values()) {
             assertThat(trust.getScore()).isGreaterThan(previous);
             previous = trust.getScore();
         }
+    }
+
+    @Test
+    void mapsScoreToTrust() {
+        for (var trust : Trust.values()) {
+            assertThat(Trust.of(trust.getScore())).isEqualTo(trust);
+        }
+    }
+
+    @Test
+    void roundsScoreUpToTrust() {
+        for (var trust : Trust.values()) {
+            assertThat(Trust.of(trust.getScore() - 1)).isEqualTo(trust);
+        }
+    }
+
+    @Test
+    void mapsExcessiveScoreToTruth() {
+        assertThat(Trust.of(666)).isEqualTo(Trust.TRUTH);
     }
 }

--- a/src/test/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractorTest.java
+++ b/src/test/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractorTest.java
@@ -5,27 +5,96 @@
 
 package com.philips.research.bombase.core.scanner.domain;
 
+import com.philips.research.bombase.core.downloader.DownloadException;
+import com.philips.research.bombase.core.downloader.DownloadService;
+import com.philips.research.bombase.core.scanner.ScannerException;
 import com.philips.research.bombase.core.scanner.ScannerService;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 class ScannerInteractorTest {
-    private static final Path DIRECTORY = Path.of("directory", "path");
+    private static final Path PATH = Path.of("directory", "path");
+    private static final URI LICENSE_URL = URI.create("http://example.com/license");
+    private static final String LICENSE = "License";
 
+    private final DownloadService downloader = mock(DownloadService.class);
     private final ScanCodeScanner scanner = mock(ScanCodeScanner.class);
-    private final ScannerService interactor = new ScannerInteractor(scanner);
+    private final ScannerService interactor = new ScannerInteractor(downloader, scanner);
 
     @Test
     void scansDirectory() {
-        when(scanner.scan(DIRECTORY)).thenReturn(mock(ScannerService.ScanResult.class));
+        //TODO This seems not much of a test
+        when(scanner.scan(PATH)).thenReturn(mock(ScannerService.ScanResult.class));
 
-        final var result = interactor.scan(DIRECTORY);
+        final var result = interactor.scan(PATH);
 
         assertThat(result).isNotNull();
+    }
+
+    @Test
+    void scansFromUrl() {
+        setupDownloader(LICENSE_URL, PATH);
+        when(scanner.scan(PATH)).thenAnswer((x) -> scanResult(LICENSE));
+
+        final var licenses = interactor.scanLicenses(LICENSE_URL);
+
+        assertThat(licenses).containsExactly(LICENSE);
+    }
+
+    @Test
+    void throws_downloadFails() {
+        when(downloader.download(eq(LICENSE_URL), any())).thenThrow(new DownloadException("Test"));
+
+        assertThatThrownBy(() -> interactor.scanLicenses(LICENSE_URL))
+                .isInstanceOf(DownloadException.class)
+                .hasMessageContaining("Test");
+    }
+
+    @Test
+    void throws_scanFails() {
+        setupDownloader(LICENSE_URL, PATH);
+        when(scanner.scan(PATH)).thenThrow(new ScannerException("Test"));
+
+        assertThatThrownBy(() -> interactor.scanLicenses(LICENSE_URL))
+                .isInstanceOf(ScannerException.class)
+                .hasMessageContaining("Test");
+    }
+
+    /**
+     * Matches the download URL and provides a path to the processor.
+     */
+    private void setupDownloader(URI url, Path path) {
+        doAnswer(a -> { // Pass download path to provided consumer
+            final Function<Path, List<String>> consumer = a.getArgument(1);
+            return consumer.apply(path);
+        }).when(downloader).download(eq(url), any());
+    }
+
+    /**
+     * Configures scanner to report the indicated licenses.
+     */
+    private ScannerService.ScanResult scanResult(String... licenses) {
+        final var list = Arrays.stream(licenses)
+                .map(lic -> {
+                    final var result = mock(ScannerService.LicenseResult.class);
+                    when(result.getExpression()).thenReturn(lic);
+                    return result;
+                })
+                .collect(Collectors.toList());
+        final var scanResult = mock(ScannerService.ScanResult.class);
+        when(scanResult.getLicenses()).thenReturn(list);
+        return scanResult;
     }
 }

--- a/src/test/java/com/philips/research/bombase/core/source_scan/domain/SourceLicensesHarvesterTest.java
+++ b/src/test/java/com/philips/research/bombase/core/source_scan/domain/SourceLicensesHarvesterTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -79,9 +80,8 @@ class SourceLicensesHarvesterTest {
         void beforeEach() {
             when(pkg.get(Field.SOURCE_LOCATION)).thenReturn(Optional.of(SOURCE_LOCATION));
             doAnswer(a -> { // Pass download path to provided consumer
-                final Consumer<Path> consumer = a.getArgument(1);
-                consumer.accept(PATH);
-                return null;
+                final Function<Path, ScanResult> operation = a.getArgument(1);
+                return operation.apply(PATH);
             }).when(downloader).download(eq(URI.create(SOURCE_LOCATION)), any());
             when(scanner.scan(PATH)).thenReturn(scanResult);
         }


### PR DESCRIPTION
Automatically converts URLs in declared licenses to the licence(s) in the referenced document.

- Maven harvester now prefers reporting license URLs (because they are more concise)
- Rewrite of the license uses the same trust level as the original value
- Licenses scanned from a URL are sorted on score
- License names from ScanCode that include "LicenseRef" in their id are deprioritized
- Downloader now supports redirects (which is not default Java behavior)