### PR TITLE
Feature/scanner persistence

### DIFF
--- a/src/main/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedAPI.java
+++ b/src/main/java/com/philips/research/bombase/core/clearlydefined/domain/ClearlyDefinedAPI.java
@@ -153,10 +153,10 @@ public interface ClearlyDefinedAPI {
         ScoreJson score;
 
         Optional<String> getDeclaredLicense() {
-            if (IGNORED_LICENSES.contains(declared)) {
+            if (declared == null || IGNORED_LICENSES.contains(declared)) {
                 return Optional.empty();
             }
-            return Optional.ofNullable(declared);
+            return Optional.of(declared);
         }
 
         List<String> getDetectedLicenses() {

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/Package.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/Package.java
@@ -34,7 +34,7 @@ public class Package {
         return lastUpdated;
     }
 
-    public <T> Attribute<T> add(Attribute<T> attribute) {
+    public synchronized <T> Attribute<T> add(Attribute<T> attribute) {
         if (attributes.contains(attribute)) {
             throw new IllegalArgumentException("The " + attribute.getField().name() + " attribute already exists in package " + purl);
         }
@@ -42,7 +42,7 @@ public class Package {
         return attribute;
     }
 
-    public <T> Optional<Attribute<T>> getAttributeFor(Field field) {
+    public synchronized <T> Optional<Attribute<T>> getAttributeFor(Field field) {
         //noinspection unchecked
         return attributes.stream()
                 .map(attr -> (Attribute<T>) attr)

--- a/src/main/java/com/philips/research/bombase/core/scanner/ScannerService.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/ScannerService.java
@@ -17,6 +17,7 @@ public interface ScannerService {
      * @param directory location of the files
      * @return results of the scan
      */
+    @Deprecated
     //TODO Not sure if we should scan files instead of an URI
     ScanResult scan(Path directory);
 

--- a/src/main/java/com/philips/research/bombase/core/scanner/ScannerService.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/ScannerService.java
@@ -7,20 +7,9 @@ package com.philips.research.bombase.core.scanner;
 
 import java.io.File;
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.List;
 
 public interface ScannerService {
-    /**
-     * Scans the files in a given directory for licenses.
-     *
-     * @param directory location of the files
-     * @return results of the scan
-     */
-    @Deprecated
-    //TODO Not sure if we should scan files instead of an URI
-    ScanResult scan(Path directory);
-
     /**
      * @return list of licenses detected in the content indicated by the URI
      */

--- a/src/main/java/com/philips/research/bombase/core/scanner/ScannerStore.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/ScannerStore.java
@@ -15,16 +15,16 @@ public interface ScannerStore {
     /**
      * Persists the result of a scan
      *
-     * @param uri  location of the scanned resources
-     * @param scan scanning results
+     * @param location location of the scanned resources
+     * @param scan     scanning results
      */
-    void store(URI uri, ScannerService.ScanResult scan);
+    void store(URI location, ScannerService.ScanResult scan);
 
     /**
      * Retrieves the prior scan result.
      *
-     * @param uri location of the resources
+     * @param location location of the resources
      * @return prior scan results (if available)
      */
-    Optional<ScannerService.ScanResult> retrieve(URI uri);
+    Optional<ScannerService.ScanResult> retrieve(URI location);
 }

--- a/src/main/java/com/philips/research/bombase/core/scanner/ScannerStore.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/ScannerStore.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.scanner;
+
+import java.net.URI;
+import java.util.Optional;
+
+/**
+ * Persistence interface for scan results.
+ */
+public interface ScannerStore {
+    /**
+     * Persists the result of a scan
+     *
+     * @param uri  location of the scanned resources
+     * @param scan scanning results
+     */
+    void store(URI uri, ScannerService.ScanResult scan);
+
+    /**
+     * Retrieves the prior scan result.
+     *
+     * @param uri location of the resources
+     * @return prior scan results (if available)
+     */
+    Optional<ScannerService.ScanResult> retrieve(URI uri);
+}

--- a/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
@@ -7,6 +7,7 @@ package com.philips.research.bombase.core.scanner.domain;
 
 import com.philips.research.bombase.core.downloader.DownloadService;
 import com.philips.research.bombase.core.scanner.ScannerService;
+import com.philips.research.bombase.core.scanner.ScannerStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,15 +22,17 @@ import java.util.stream.Collectors;
 public class ScannerInteractor implements ScannerService {
     private static final Logger LOG = LoggerFactory.getLogger(ScannerInteractor.class);
 
+    private final ScannerStore store;
     private final DownloadService downloader;
     private final ScanCodeScanner scanner;
 
     @Autowired
-    public ScannerInteractor(DownloadService downloader) {
-        this(downloader, new ScanCodeScanner());
+    public ScannerInteractor(ScannerStore store, DownloadService downloader) {
+        this(store, downloader, new ScanCodeScanner());
     }
 
-    ScannerInteractor(DownloadService downloader, ScanCodeScanner scanner) {
+    ScannerInteractor(ScannerStore store, DownloadService downloader, ScanCodeScanner scanner) {
+        this.store = store;
         this.downloader = downloader;
         this.scanner = scanner;
     }
@@ -40,13 +43,22 @@ public class ScannerInteractor implements ScannerService {
     }
 
     @Override
-    public List<String> scanLicenses(URI uri) {
-        final var licenses = downloader.download(uri, scanner::scan)
+    public List<String> scanLicenses(URI location) {
+        final var licenses = loadOrScan(location)
                 .getLicenses().stream()
                 .sorted((l, r) -> Integer.compare(r.getScore(), l.getScore()))
                 .map(LicenseResult::getExpression)
                 .collect(Collectors.toList());
-        LOG.info("Scanned {} =>{}", uri, licenses);
+        LOG.info("Scanned {} =>{}", location, licenses);
         return licenses;
+    }
+
+    private ScanResult loadOrScan(URI location) {
+        return store.retrieve(location)
+                .orElseGet(() -> {
+                    final var result = downloader.download(location, scanner::scan);
+                    store.store(location, result);
+                    return result;
+                });
     }
 }

--- a/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractor.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,11 +34,6 @@ public class ScannerInteractor implements ScannerService {
         this.store = store;
         this.downloader = downloader;
         this.scanner = scanner;
-    }
-
-    @Override
-    public ScanResult scan(Path directory) {
-        return scanner.scan(directory);
     }
 
     @Override

--- a/src/main/java/com/philips/research/bombase/persistence/MemoryScannerStore.java
+++ b/src/main/java/com/philips/research/bombase/persistence/MemoryScannerStore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.persistence;
+
+import com.philips.research.bombase.core.scanner.ScannerService;
+import com.philips.research.bombase.core.scanner.ScannerStore;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class MemoryScannerStore implements ScannerStore {
+    private final Map<URI, ScannerService.ScanResult> scans = new HashMap<>();
+
+    @Override
+    public void store(URI uri, ScannerService.ScanResult scan) {
+        scans.put(uri, scan);
+    }
+
+    @Override
+    public Optional<ScannerService.ScanResult> retrieve(URI uri) {
+        return Optional.ofNullable(scans.get(uri));
+    }
+}

--- a/src/main/java/com/philips/research/bombase/persistence/MemoryScannerStore.java
+++ b/src/main/java/com/philips/research/bombase/persistence/MemoryScannerStore.java
@@ -7,22 +7,24 @@ package com.philips.research.bombase.persistence;
 
 import com.philips.research.bombase.core.scanner.ScannerService;
 import com.philips.research.bombase.core.scanner.ScannerStore;
+import org.springframework.stereotype.Repository;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+@Repository
 public class MemoryScannerStore implements ScannerStore {
     private final Map<URI, ScannerService.ScanResult> scans = new HashMap<>();
 
     @Override
-    public void store(URI uri, ScannerService.ScanResult scan) {
-        scans.put(uri, scan);
+    public void store(URI location, ScannerService.ScanResult scan) {
+        scans.put(location, scan);
     }
 
     @Override
-    public Optional<ScannerService.ScanResult> retrieve(URI uri) {
-        return Optional.ofNullable(scans.get(uri));
+    public Optional<ScannerService.ScanResult> retrieve(URI location) {
+        return Optional.ofNullable(scans.get(location));
     }
 }

--- a/src/test/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractorTest.java
+++ b/src/test/java/com/philips/research/bombase/core/scanner/domain/ScannerInteractorTest.java
@@ -38,16 +38,6 @@ class ScannerInteractorTest {
     private final ScannerService interactor = new ScannerInteractor(store, downloader, scanner);
 
     @Test
-    void scansDirectory() {
-        //TODO This seems not much of a test
-        when(scanner.scan(PATH)).thenReturn(mock(ScannerService.ScanResult.class));
-
-        final var result = interactor.scan(PATH);
-
-        assertThat(result).isNotNull();
-    }
-
-    @Test
     void scansFromUrl() {
         setupDownloader(LICENSE_URL, PATH);
         final var scanResult = scanResult(LICENSE);


### PR DESCRIPTION
Because the license scanner did not have memory, it kept downloading and re-scanning license URLs. This is now solved by caching all scan results in an in-memory store.

Also fixed a few small issues:
- Reduced (=fix?) occasional concurrent modification exceptions
- Fixed null pointer exception on missing declared license in ClearlyDefined response
- Scanner now internally invokes the downloader