### PR TITLE
Feat(Backend): Indicate changed value only for actual change

### DIFF
--- a/src/main/java/com/philips/research/bombase/core/meta/AbstractRepoHarvester.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/AbstractRepoHarvester.java
@@ -11,6 +11,7 @@ import com.philips.research.bombase.core.meta.registry.MetaRegistry;
 import com.philips.research.bombase.core.meta.registry.PackageAttributeEditor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import pl.tlinkowski.annotation.basic.NullOr;
 
 import java.util.Map;
 import java.util.Optional;
@@ -30,7 +31,7 @@ public abstract class AbstractRepoHarvester implements MetaRegistry.PackageListe
     }
 
     @Override
-    public Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, Object> values) {
+    public Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, @NullOr Object> values) {
         if (!isSupportedType(purl.getType()) || !updated.isEmpty()) {
             return Optional.empty();
         }

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/Attribute.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/Attribute.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Current value for a field.
+ * Current metadata value for a field.
  */
 public class Attribute<T> implements AttributeValue<T> {
     private final Field field;
@@ -37,31 +37,6 @@ public class Attribute<T> implements AttributeValue<T> {
         return score;
     }
 
-    boolean setValue(Trust trust, @NullOr T value) {
-        int score = trust.getScore();
-        if (value == null) {
-            return false;
-        }
-
-        field.validate(value);
-        if (trust == Trust.TRUTH) {
-            updateTruth(value);
-            return true;
-        } else if (score >= this.score) {
-            return updateValue(score, value);
-        } else {
-            updateAltValue(score, value);
-            return false;
-        }
-    }
-
-    private void updateTruth(@NullOr T value) {
-        this.score = Trust.TRUTH.getScore();
-        this.value = value;
-        this.altScore = 0;
-        this.altValue = null;
-    }
-
     @Override
     public Optional<T> getAltValue() {
         return Optional.ofNullable((altScore > 0) ? altValue : null);
@@ -72,28 +47,56 @@ public class Attribute<T> implements AttributeValue<T> {
         return altScore;
     }
 
-    private void updateAltValue(int score, @NullOr T value) {
-        if (score >= this.altScore) {
-            this.altScore = score;
-            this.altValue = value;
+    /**
+     * Potentially updates the current and alternative value.
+     *
+     * @param trust indication of how certain the caller is of the value
+     * @param value the new value
+     * @return true if the main value was updated (which is independent from score updates or alt value changes)
+     */
+    boolean setValue(Trust trust, @NullOr T value) {
+        int score = trust.getScore();
+        if (value == null) {
+            return false;
         }
-    }
 
-    private boolean updateValue(int score, @NullOr T value) {
-        if (!Objects.equals(this.value, value)) {
-            replaceValue(score, value);
-            return true;
+        field.validate(value);
+        if (trust == Trust.TRUTH) {
+            return updateTruth(value);
+        } else if (score >= this.score) {
+            return updateValue(score, value);
         } else {
-            this.score = score;
+            updateAltValue(score, value);
             return false;
         }
     }
 
-    private void replaceValue(int score, @NullOr T value) {
+    private boolean updateTruth(T value) {
+        this.value = value;
+        this.score = Trust.TRUTH.getScore();
+        this.altValue = null;
+        this.altScore = Trust.NONE.getScore();
+        return true;
+    }
+
+    private boolean updateValue(int score, T value) {
+        if (Objects.equals(this.value, value)) {
+            this.score = score;
+            return false;
+        }
         this.altScore = this.score;
         this.altValue = this.value;
-        this.value = value;
         this.score = score;
+        this.value = value;
+        return true;
+    }
+
+    private void updateAltValue(int score, T value) {
+        if (score < this.altScore) {
+            return;
+        }
+        this.altScore = score;
+        this.altValue = value;
     }
 
     @Override

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/MetaRegistry.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/MetaRegistry.java
@@ -10,6 +10,7 @@ import com.philips.research.bombase.core.meta.MetaStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import pl.tlinkowski.annotation.basic.NullOr;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -79,7 +80,7 @@ public class MetaRegistry {
         }
     }
 
-    private void notifyListeners(PackageURL purl, Set<Field> modifiedFields, Map<Field, Object> values) {
+    private void notifyListeners(PackageURL purl, Set<Field> modifiedFields, Map<Field, @NullOr Object> values) {
         listeners.forEach(l -> {
             l.onUpdated(purl, modifiedFields, values)
                     .ifPresent(task -> {
@@ -101,6 +102,6 @@ public class MetaRegistry {
          * @param values  current package metadata
          * @return (optional) operation to queue for execution
          */
-        Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, Object> values);
+        Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, @NullOr Object> values);
     }
 }

--- a/src/test/java/com/philips/research/bombase/core/meta/registry/AttributeTest.java
+++ b/src/test/java/com/philips/research/bombase/core/meta/registry/AttributeTest.java
@@ -17,97 +17,180 @@ class AttributeTest {
     private static final String OTHER_VALUE = "Other";
     private static final Field FIELD = Field.TITLE;
     private static final Trust TRUST = Trust.PROBABLY;
-    private static final Trust HIGHER_TRUST = Trust.CERTAIN;
-    private static final Trust LOWER_TRUST = Trust.MAYBE;
+    private static final Trust HIGHER_TRUST = Trust.values()[TRUST.ordinal() + 1];
+    private static final Trust LOWER_TRUST = Trust.values()[TRUST.ordinal() - 1];
 
     private final Attribute<Object> field = new Attribute<>(FIELD);
 
     @Test
     void createsInstance() {
         assertThat(field.getField()).isEqualTo(FIELD);
+        assertThat(field.getScore()).isEqualTo(Trust.NONE.getScore());
         assertThat(field.getValue()).isEmpty();
+        assertThat(field.getAltScore()).isEqualTo(Trust.NONE.getScore());
         assertThat(field.getAltValue()).isEmpty();
     }
 
     @Test
-    void setsValue() {
+    void setsInitialValue() {
         final var modified = field.setValue(TRUST, VALUE);
 
         assertThat(modified).isTrue();
         assertThat(field.getValue()).contains(VALUE);
-        assertThat(field.getAltValue()).isEmpty();
+        assertThat(field.getScore()).isEqualTo(TRUST.getScore());
     }
 
     @Test
     void overridesValue_equalTrust() {
         field.setValue(TRUST, VALUE);
+
         final var modified = field.setValue(TRUST, OTHER_VALUE);
 
         assertThat(modified).isTrue();
         assertThat(field.getValue()).contains(OTHER_VALUE);
+        assertThat(field.getScore()).isEqualTo(TRUST.getScore());
         assertThat(field.getAltValue()).contains(VALUE);
+        assertThat(field.getAltScore()).isEqualTo(TRUST.getScore());
+    }
+
+    @Test
+    void increasesTrust() {
+        field.setValue(TRUST, VALUE);
+
+        final var modified = field.setValue(HIGHER_TRUST, VALUE);
+
+        assertThat(modified).isFalse();
+        assertThat(field.getValue()).contains(VALUE);
+        assertThat(field.getScore()).isEqualTo(HIGHER_TRUST.getScore());
+        assertThat(field.getAltValue()).isEmpty();
     }
 
     @Test
     void overridesValue_higherTrust() {
         field.setValue(TRUST, VALUE);
+
         final var modified = field.setValue(HIGHER_TRUST, OTHER_VALUE);
 
         assertThat(modified).isTrue();
         assertThat(field.getValue()).contains(OTHER_VALUE);
+        assertThat(field.getScore()).isEqualTo(HIGHER_TRUST.getScore());
         assertThat(field.getAltValue()).contains(VALUE);
+        assertThat(field.getAltScore()).isEqualTo(TRUST.getScore());
     }
 
     @Test
-    void ignoresIdenticalValue() {
-        field.setValue(TRUST, VALUE);
-        final var modified = field.setValue(HIGHER_TRUST, VALUE);
+    void overridesTruth() {
+        field.setValue(Trust.TRUTH, VALUE);
 
-        assertThat(modified).isFalse();
+        final var modified = field.setValue(Trust.TRUTH, OTHER_VALUE);
+
+        assertThat(modified).isTrue();
+        assertThat(field.getValue()).contains(OTHER_VALUE);
         assertThat(field.getAltValue()).isEmpty();
+    }
+
+    @Test
+    void confirmsTruth() {
+        field.setValue(Trust.TRUTH, VALUE);
+
+        final var modified = field.setValue(Trust.TRUTH, VALUE);
+
+        assertThat(modified).isTrue();
     }
 
     @Test
     void contestsValue_lowerScore() {
         field.setValue(TRUST, VALUE);
+
         final var modified = field.setValue(LOWER_TRUST, OTHER_VALUE);
 
         assertThat(modified).isFalse();
         assertThat(field.getValue()).contains(VALUE);
+        assertThat(field.getScore()).isEqualTo(TRUST.getScore());
         assertThat(field.getAltValue()).contains(OTHER_VALUE);
+        assertThat(field.getAltScore()).isEqualTo(LOWER_TRUST.getScore());
     }
 
     @Test
     void overridesValueAndContestingValue() {
         field.setValue(LOWER_TRUST, "Replaced");
         field.setValue(TRUST, VALUE);
+
         final var modified = field.setValue(HIGHER_TRUST, OTHER_VALUE);
 
         assertThat(modified).isTrue();
         assertThat(field.getValue()).contains(OTHER_VALUE);
+        assertThat(field.getScore()).isEqualTo(HIGHER_TRUST.getScore());
         assertThat(field.getAltValue()).contains(VALUE);
+        assertThat(field.getAltScore()).isEqualTo(TRUST.getScore());
     }
 
     @Test
     void overridesContestingValue() {
         field.setValue(HIGHER_TRUST, VALUE);
         field.setValue(LOWER_TRUST, "Replaced");
+
         final var modified = field.setValue(TRUST, OTHER_VALUE);
 
         assertThat(modified).isFalse();
         assertThat(field.getValue()).contains(VALUE);
+        assertThat(field.getScore()).isEqualTo(HIGHER_TRUST.getScore());
         assertThat(field.getAltValue()).contains(OTHER_VALUE);
+        assertThat(field.getAltScore()).isEqualTo(TRUST.getScore());
+    }
+
+    @Test
+    void ignoresNonContestingValue() {
+        field.setValue(HIGHER_TRUST, VALUE);
+        field.setValue(TRUST, OTHER_VALUE);
+
+        final var modified = field.setValue(LOWER_TRUST, "Ignored");
+
+        assertThat(modified).isFalse();
+        assertThat(field.getValue()).contains(VALUE);
+        assertThat(field.getScore()).isEqualTo(HIGHER_TRUST.getScore());
+        assertThat(field.getAltValue()).contains(OTHER_VALUE);
+        assertThat(field.getAltScore()).isEqualTo(TRUST.getScore());
     }
 
     @Test
     void promotesContestingValue() {
         field.setValue(LOWER_TRUST, VALUE);
         field.setValue(TRUST, OTHER_VALUE);
+
         final var modified = field.setValue(HIGHER_TRUST, VALUE);
 
         assertThat(modified).isTrue();
         assertThat(field.getValue()).contains(VALUE);
+        assertThat(field.getScore()).isEqualTo(HIGHER_TRUST.getScore());
         assertThat(field.getAltValue()).contains(OTHER_VALUE);
+        assertThat(field.getAltScore()).isEqualTo(TRUST.getScore());
+    }
+
+    @Test
+    void increasesTrustOfContestingValue() {
+        field.setValue(Trust.TRUTH, OTHER_VALUE);
+        field.setValue(LOWER_TRUST, VALUE);
+
+        final var modified = field.setValue(HIGHER_TRUST, VALUE);
+
+        assertThat(modified).isFalse();
+        assertThat(field.getValue()).contains(OTHER_VALUE);
+        assertThat(field.getScore()).isEqualTo(Trust.TRUTH.getScore());
+        assertThat(field.getAltValue()).contains(VALUE);
+        assertThat(field.getAltScore()).isEqualTo(HIGHER_TRUST.getScore());
+    }
+
+    @Test
+    void ignoresEqualContestingValue() {
+        field.setValue(HIGHER_TRUST, VALUE);
+        field.setValue(LOWER_TRUST, OTHER_VALUE);
+
+        final var modified = field.setValue(LOWER_TRUST, OTHER_VALUE);
+
+        assertThat(modified).isFalse();
+        assertThat(field.getAltValue()).contains(OTHER_VALUE);
+        assertThat(field.getAltScore()).isEqualTo(LOWER_TRUST.getScore());
     }
 
     @Test


### PR DESCRIPTION
Because the cascading harvesters rely on the boolean flag of the field value
update, this now only indicates `true` if the main value changed.

Also improved test coverage and added explicit checks for the scores.