### PR TITLE
Feature/license cleaner curation

### DIFF
--- a/src/main/java/com/philips/research/bombase/controller/LicensesRoute.java
+++ b/src/main/java/com/philips/research/bombase/controller/LicensesRoute.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.controller;
+
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import com.philips.research.bombase.core.MetaService;
+import com.philips.research.bombase.core.UnknownPackageException;
+import com.philips.research.bombase.core.license_cleaner.LicenseCleanerService;
+import org.springframework.boot.web.server.WebServerException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import pl.tlinkowski.annotation.basic.NullOr;
+import retrofit2.http.Body;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping("/licenses")
+public class LicensesRoute {
+    private final LicenseCleanerService service;
+
+    LicensesRoute(LicenseCleanerService service) {
+        this.service = service;
+    }
+
+    @PostMapping()
+    void setLicenseCuration(@RequestBody CurationJson body) {
+        if (body.license == null || body.curation==null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Need license and curation in body");
+        }
+        service.defineCuration(body.license, body.curation);
+    }
+
+    static class CurationJson {
+        @NullOr String license;
+        @NullOr String curation;
+    }
+}

--- a/src/main/java/com/philips/research/bombase/controller/LicensesRoute.java
+++ b/src/main/java/com/philips/research/bombase/controller/LicensesRoute.java
@@ -5,21 +5,11 @@
 
 package com.philips.research.bombase.controller;
 
-import com.github.packageurl.MalformedPackageURLException;
-import com.github.packageurl.PackageURL;
-import com.philips.research.bombase.core.MetaService;
-import com.philips.research.bombase.core.UnknownPackageException;
 import com.philips.research.bombase.core.license_cleaner.LicenseCleanerService;
-import org.springframework.boot.web.server.WebServerException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import pl.tlinkowski.annotation.basic.NullOr;
-import retrofit2.http.Body;
-
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 @RestController
 @CrossOrigin(origins = "*")
@@ -33,7 +23,7 @@ public class LicensesRoute {
 
     @PostMapping()
     void setLicenseCuration(@RequestBody CurationJson body) {
-        if (body.license == null || body.curation==null) {
+        if (body.license == null || body.curation == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Need license and curation in body");
         }
         service.defineCuration(body.license, body.curation);

--- a/src/main/java/com/philips/research/bombase/core/license_cleaner/LicenseCleanerService.java
+++ b/src/main/java/com/philips/research/bombase/core/license_cleaner/LicenseCleanerService.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.license_cleaner;
+
+/**
+ * Configuration of the license cleaner.
+ */
+public interface LicenseCleanerService {
+    /**
+     * Configures a curation for a URL as override to scanning the content of the URL.
+     */
+   void defineCuration(String url, String license);
+}

--- a/src/main/java/com/philips/research/bombase/core/license_cleaner/LicenseCleanerService.java
+++ b/src/main/java/com/philips/research/bombase/core/license_cleaner/LicenseCleanerService.java
@@ -12,5 +12,5 @@ public interface LicenseCleanerService {
     /**
      * Configures a curation for a URL as override to scanning the content of the URL.
      */
-   void defineCuration(String url, String license);
+    void defineCuration(String url, String license);
 }

--- a/src/main/java/com/philips/research/bombase/core/license_cleaner/LicenseCleanerStore.java
+++ b/src/main/java/com/philips/research/bombase/core/license_cleaner/LicenseCleanerStore.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.license_cleaner;
+
+import java.util.Optional;
+
+/**
+ * Persistence interface for the LicenseCleaner.
+ */
+public interface LicenseCleanerStore {
+    /**
+     * @return (optional) curation for the license (URL)
+     */
+    Optional<String> findCuration(String license);
+
+    /**
+     * Persists a license curation
+     */
+    void storeCuration(String license, String curation);
+}

--- a/src/main/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleaner.java
+++ b/src/main/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleaner.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package com.philips.research.bombase.core.license.domain;
+package com.philips.research.bombase.core.license_cleaner.domain;
 
 import com.github.packageurl.PackageURL;
 import com.philips.research.bombase.core.meta.registry.Field;

--- a/src/main/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleanerInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleanerInteractor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.license_cleaner.domain;
+
+import com.philips.research.bombase.core.license_cleaner.LicenseCleanerService;
+import com.philips.research.bombase.core.license_cleaner.LicenseCleanerStore;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LicenseCleanerInteractor implements LicenseCleanerService {
+    private final LicenseCleanerStore store;
+
+    public LicenseCleanerInteractor(LicenseCleanerStore store) {
+        this.store = store;
+    }
+
+    @Override
+    public void defineCuration(String url, String license) {
+        store.storeCuration(url, license);
+    }
+}

--- a/src/main/java/com/philips/research/bombase/core/license_cleaner/domain/package-info.java
+++ b/src/main/java/com/philips/research/bombase/core/license_cleaner/domain/package-info.java
@@ -4,4 +4,4 @@
  */
 
 @pl.tlinkowski.annotation.basic.NonNullPackage
-package com.philips.research.bombase.core.license.domain;
+package com.philips.research.bombase.core.license_cleaner.domain;

--- a/src/main/java/com/philips/research/bombase/core/license_cleaner/package-info.java
+++ b/src/main/java/com/philips/research/bombase/core/license_cleaner/package-info.java
@@ -4,4 +4,4 @@
  */
 
 @pl.tlinkowski.annotation.basic.NonNullPackage
-package com.philips.research.bombase.core.license;
+package com.philips.research.bombase.core.license_cleaner;

--- a/src/main/java/com/philips/research/bombase/core/meta/MetaInteractor.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/MetaInteractor.java
@@ -10,7 +10,7 @@ import com.philips.research.bombase.ConfigProperties;
 import com.philips.research.bombase.core.MetaService;
 import com.philips.research.bombase.core.UnknownPackageException;
 import com.philips.research.bombase.core.clearlydefined.domain.ClearlyDefinedHarvester;
-import com.philips.research.bombase.core.license.domain.LicenseCleaner;
+import com.philips.research.bombase.core.license_cleaner.domain.LicenseCleaner;
 import com.philips.research.bombase.core.maven.domain.MavenHarvester;
 import com.philips.research.bombase.core.meta.registry.Field;
 import com.philips.research.bombase.core.meta.registry.MetaRegistry;

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/MetaRegistry.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/MetaRegistry.java
@@ -10,7 +10,6 @@ import com.philips.research.bombase.core.meta.MetaStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import pl.tlinkowski.annotation.basic.NullOr;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -80,14 +79,12 @@ public class MetaRegistry {
         }
     }
 
-    private void notifyListeners(PackageURL purl, Set<Field> modifiedFields, Map<Field, @NullOr Object> values) {
-        listeners.forEach(l -> {
-            l.onUpdated(purl, modifiedFields, values)
-                    .ifPresent(task -> {
-                        LOG.info("Scheduled {} task for {}", nameFor(l), purl);
-                        runner.execute(purl, task, this::cascadeListeners);
-                    });
-        });
+    private void notifyListeners(PackageURL purl, Set<Field> modifiedFields, Map<Field, Object> values) {
+        listeners.forEach(l -> l.onUpdated(purl, modifiedFields, values)
+                .ifPresent(task -> {
+                    LOG.info("Scheduled {} task for {}", nameFor(l), purl);
+                    runner.execute(purl, task, this::cascadeListeners);
+                }));
     }
 
     /**
@@ -102,6 +99,6 @@ public class MetaRegistry {
          * @param values  current package metadata
          * @return (optional) operation to queue for execution
          */
-        Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, @NullOr Object> values);
+        Optional<Consumer<PackageAttributeEditor>> onUpdated(PackageURL purl, Set<Field> updated, Map<Field, Object> values);
     }
 }

--- a/src/main/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditor.java
+++ b/src/main/java/com/philips/research/bombase/core/meta/registry/PackageAttributeEditor.java
@@ -42,7 +42,7 @@ public class PackageAttributeEditor {
     /**
      * @return snapshot of the current fields with values
      */
-    public Map<Field, @NullOr Object> getValues() {
+    public Map<Field, Object> getValues() {
         return pkg.getAttributes()
                 .filter(a -> a.getValue().isPresent())
                 .collect(Collectors.toMap(Attribute::getField, attribute -> attribute.getValue().get()));

--- a/src/main/java/com/philips/research/bombase/persistence/MemoryLicenseCleanerStore.java
+++ b/src/main/java/com/philips/research/bombase/persistence/MemoryLicenseCleanerStore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.persistence;
+
+import com.philips.research.bombase.core.license_cleaner.LicenseCleanerStore;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class MemoryLicenseCleanerStore implements LicenseCleanerStore {
+    private final Map<String, String> curations = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<String> findCuration(String license) {
+        return Optional.ofNullable(curations.get(license.toLowerCase()));
+    }
+
+    @Override
+    public void storeCuration(String license, String curation) {
+        curations.put(license.toLowerCase(), curation);
+    }
+}

--- a/src/main/java/com/philips/research/bombase/persistence/MemoryScannerStore.java
+++ b/src/main/java/com/philips/research/bombase/persistence/MemoryScannerStore.java
@@ -10,13 +10,13 @@ import com.philips.research.bombase.core.scanner.ScannerStore;
 import org.springframework.stereotype.Repository;
 
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class MemoryScannerStore implements ScannerStore {
-    private final Map<URI, ScannerService.ScanResult> scans = new HashMap<>();
+    private final Map<URI, ScannerService.ScanResult> scans = new ConcurrentHashMap<>();
 
     @Override
     public void store(URI location, ScannerService.ScanResult scan) {

--- a/src/test/java/com/philips/research/bombase/controller/LicensesRouteTest.java
+++ b/src/test/java/com/philips/research/bombase/controller/LicensesRouteTest.java
@@ -41,12 +41,8 @@ public class LicensesRouteTest {
     @MockBean
     private LicenseCleanerService service;
 
-    private static String encode(String string) {
-        return URLEncoder.encode(string, StandardCharsets.UTF_8);
-    }
-
     @BeforeEach
-    void beforeEach() throws Exception {
+    void beforeEach() {
         Mockito.reset(service);
     }
 

--- a/src/test/java/com/philips/research/bombase/controller/LicensesRouteTest.java
+++ b/src/test/java/com/philips/research/bombase/controller/LicensesRouteTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.controller;
+
+import com.philips.research.bombase.core.license_cleaner.LicenseCleanerService;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {LicensesRoute.class, JacksonConfiguration.class})
+@AutoConfigureMockMvc
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+public class LicensesRouteTest {
+    private static final String CURATION_URL = "/licenses";
+    private static final String LICENSE_URL = "https://example.com/license";
+    private static final String LICENSE = "License";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private LicenseCleanerService service;
+
+    private static String encode(String string) {
+        return URLEncoder.encode(string, StandardCharsets.UTF_8);
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        Mockito.reset(service);
+    }
+
+    @Test
+    void registersLicenseCuration() throws Exception {
+        final var json = new JSONObject()
+                .put("license", LICENSE_URL)
+                .put("curation", LICENSE);
+        mvc.perform(post(CURATION_URL)
+                .content(json.toString()).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(service).defineCuration(LICENSE_URL, LICENSE);
+    }
+
+    @Test
+    void badRequest_registerLicenseWithoutParameters() throws Exception {
+        mvc.perform(post(CURATION_URL)
+                .content("{}").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleanerInteractorTest.java
+++ b/src/test/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleanerInteractorTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.bombase.core.license_cleaner.domain;
+
+import com.philips.research.bombase.core.license_cleaner.LicenseCleanerService;
+import com.philips.research.bombase.core.license_cleaner.LicenseCleanerStore;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class LicenseCleanerInteractorTest {
+    private static final String URL = "http://example.com/license";
+    private static final String LICENSE = "License";
+
+    private final LicenseCleanerStore store = mock(LicenseCleanerStore.class);
+    private final LicenseCleanerService interactor = new LicenseCleanerInteractor(store);
+
+    @Test
+    void storesCuration() {
+        interactor.defineCuration(URL, LICENSE);
+
+        verify(store).storeCuration(URL, LICENSE);
+    }
+}

--- a/src/test/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleanerTest.java
+++ b/src/test/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleanerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package com.philips.research.bombase.core.license.domain;
+package com.philips.research.bombase.core.license_cleaner.domain;
 
 import com.github.packageurl.PackageURL;
 import com.philips.research.bombase.core.downloader.DownloadService;

--- a/src/test/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleanerTest.java
+++ b/src/test/java/com/philips/research/bombase/core/license_cleaner/domain/LicenseCleanerTest.java
@@ -6,7 +6,7 @@
 package com.philips.research.bombase.core.license_cleaner.domain;
 
 import com.github.packageurl.PackageURL;
-import com.philips.research.bombase.core.downloader.DownloadService;
+import com.philips.research.bombase.core.license_cleaner.LicenseCleanerStore;
 import com.philips.research.bombase.core.meta.registry.Field;
 import com.philips.research.bombase.core.meta.registry.Package;
 import com.philips.research.bombase.core.meta.registry.PackageAttributeEditor;
@@ -17,10 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -31,9 +28,9 @@ class LicenseCleanerTest {
     private static final String LICENSE_URL = "https://example.com/license";
     private static final PackageURL PURL = purlOf("pkg:generic/name@version");
 
-    private final DownloadService downloader = mock(DownloadService.class);
+    private final LicenseCleanerStore store = mock(LicenseCleanerStore.class);
     private final ScannerService scanner = mock(ScannerService.class);
-    private final LicenseCleaner cleaner = new LicenseCleaner(scanner);
+    private final LicenseCleaner cleaner = new LicenseCleaner(store, scanner);
 
     private static PackageURL purlOf(String purl) {
         try {
@@ -88,6 +85,16 @@ class LicenseCleanerTest {
             task.accept(editor);
 
             verify(editor).update(Field.DECLARED_LICENSE, TRUST, PREFIX + LICENSE + POSTFIX);
+        }
+
+        @Test
+        void replacesUrlByCuratedLicense() {
+            editor.update(Field.DECLARED_LICENSE, TRUST, LICENSE_URL);
+            when(store.findCuration(LICENSE_URL)).thenReturn(Optional.of(LICENSE));
+
+            task.accept(editor);
+
+            verify(editor).update(Field.DECLARED_LICENSE, TRUST, LICENSE);
         }
 
         @Test


### PR DESCRIPTION
Adds persisted license URL curations that can be set by a Rest API.

This should allow for pre-defining license URLs that do not point to a page that is not properly scanned by ScanCode Toolkit.